### PR TITLE
Slightly clarifying provenance / early history...

### DIFF
--- a/tuf-spec.0.9.txt
+++ b/tuf-spec.0.9.txt
@@ -39,17 +39,16 @@ Version 0.9
    (http://www.geni.net/)
    (http://www.nsf.gov/)
 
-   TUF's reference implementation is based heavily on Thandy, the application
-   updater for Tor (http://www.torproject.org/). Its design and this spec are
-   also largely based on Thandy's, with many parts being directly borrowed
-   from Thandy. The Thandy spec can be found here:
+   TUF's reference implementation is based on prior work on Thandy, the application
+   updater for Tor (http://www.torproject.org/). TUF's design and this spec
+   also came from ideas jointly developed in discussion with Thandy's authors.
+   The Thandy spec can be found here:
    https://gitweb.torproject.org/thandy.git?a=blob_plain;f=specs/thandy-spec.txt;hb=HEAD
 
    Whereas Thandy is an application updater for an individual software project,
    TUF aims to provide a way to secure any software update system. We're very
-   grateful to the Tor Project and the Thandy developers as it is doubtful our
-   design and implementation would have been anywhere near as good without
-   being able to use their great work as a starting point. Thandy is the hard
+   grateful to the Tor Project and the Thandy developers for the early discussion
+   that led to the ideas in Thandy and TUF. Thandy is the hard
    work of Nick Mathewson, Sebastian Hahn, Roger Dingledine, Martin Peck, and
    others.
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -60,18 +60,17 @@ repo](https://github.com/theupdateframework/specification/issues).
    and the [National Science Foundation](https://www.nsf.gov/) (NSF) have
    provided support for the development of TUF.
 
-   TUF's reference implementation is based heavily on
+   TUF's reference implementation is based on prior work on
    [Thandy](https://www.torproject.org/), the application
    updater for Tor. Its design and this spec are
-   also largely based on Thandy's, with many parts being directly borrowed
-   from Thandy. The Thandy spec can be found at
+   also came from ideas jointly developed in discussion with Thandy's authors. 
+   The Thandy spec can be found at
    https://gitweb.torproject.org/thandy.git/tree/specs/thandy-spec.txt
 
    Whereas Thandy is an application updater for an individual software project,
    TUF aims to provide a way to secure any software update system. We're very
-   grateful to the Tor Project and the Thandy developers as it is doubtful our
-   design and implementation would have been anywhere near as good without
-   being able to use their great work as a starting point. Thandy is the hard
+   grateful to the Tor Project and the Thandy developers for the early discussion
+   that led to the ideas in Thandy and TUF. Thandy is the hard
    work of Nick Mathewson, Sebastian Hahn, Roger Dingledine, Martin Peck, and
    others.
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -62,8 +62,8 @@ repo](https://github.com/theupdateframework/specification/issues).
 
    TUF's reference implementation is based on prior work on
    [Thandy](https://www.torproject.org/), the application
-   updater for Tor. Its design and this spec are
-   also came from ideas jointly developed in discussion with Thandy's authors. 
+   updater for Tor. Its design and this spec
+   also came from ideas jointly developed in discussion with Thandy's authors.
    The Thandy spec can be found at
    https://gitweb.torproject.org/thandy.git/tree/specs/thandy-spec.txt
 


### PR DESCRIPTION
It's odd to fix this so late in the project's lifecycle, but the spec should probably be a bit more accurate in describing the history of TUF and Thandy.  Jake and Roger visited UW (while Justin S. and Justin C. were there) and the brainstorming discussions we had there laid the groundwork for Thandy, which Nick, Jake, Roger, and possibly others I am unaware of designed.  The Thandy authors then reached out to Justin S. and Justin C. to examine Thandy.  The creation of TUF (by Justin S. and Justin C.) came from looking at issues with Thandy where we thought security could be improved (e.g., the lack of a snapshot role).  We also tried to build TUF as a library so that others did not need to do a design like Thandy in order to have a secure updater.

Note, this is my recollection of events and memory is not perfect.  If someone else has a different recollection about any of my "facts" above, please let me know and I can adjust or annotate what is written.