### PR TITLE
0.9 timestamp example was missing "version"

### DIFF
--- a/tuf-spec.0.9.txt
+++ b/tuf-spec.0.9.txt
@@ -865,7 +865,8 @@ Version 0.9
       "hashes": {
        "sha256": "c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681"
       }, 
-      "length": 1007
+      "length": 1007,
+      "version": 1
      }
     }, 
     "version": 1


### PR DESCRIPTION
The 0.9 tuf spec in section 4.6 mentions that "version" is included in the signed portion of timestamp.json, but was missing from the example file. This adds it.

Feel free to reject this patch if you want to leave 0.9 as a historical document.