### PR TITLE
Fix keyids in the 1.0 spec

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -615,7 +615,7 @@ repo](https://github.com/theupdateframework/specification/issues).
        {
        "signatures": [
         {
-         "keyid": "f2d5020d08aea06a0a9192eb6a4f549e17032ebefa1aa9ac167c1e3e727930d6",
+         "keyid": "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4",
          "sig": "a312b9c3cb4a1b693e8ebac5ee1ca9cc01f2661c14391917dcb111517f72370809
                  f32c890c6b801e30158ac4efe0d4d87317223077784c7a378834249d048306"
         }
@@ -626,28 +626,28 @@ repo](https://github.com/theupdateframework/specification/issues).
         "consistent_snapshot": false,
         "expires": "2030-01-01T00:00:00Z",
         "keys": {
-         "1a2b4110927d4cba257262f614896179ff85ca1f1353a41b5224ac474ca71cb4": {
+         "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3": {
           "keytype": "ed25519",
           "scheme": "ed25519",
           "keyval": {
            "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"
           }
          },
-         "93ec2c3dec7cc08922179320ccd8c346234bf7f21705268b93e990d5273a2a3b": {
+         "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164": {
           "keytype": "ed25519",
           "scheme": "ed25519",
           "keyval": {
            "public": "68ead6e54a43f8f36f9717b10669d1ef0ebb38cee6b05317669341309f1069cb"
           }
          },
-         "f2d5020d08aea06a0a9192eb6a4f549e17032ebefa1aa9ac167c1e3e727930d6": {
+         "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4": {
           "keytype": "ed25519",
           "scheme": "ed25519",
           "keyval": {
            "public": "66dd78c5c2a78abc6fc6b267ff1a8017ba0e8bfc853dd97af351949bba021275"
           }
          },
-         "fce9cf1cc86b0945d6a042f334026f31ed8e4ee1510218f198e8d3f191d15309": {
+         "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc": {
           "keytype": "ed25519",
           "scheme": "ed25519",
           "keyval": {
@@ -658,25 +658,25 @@ repo](https://github.com/theupdateframework/specification/issues).
         "roles": {
          "root": {
           "keyids": [
-           "f2d5020d08aea06a0a9192eb6a4f549e17032ebefa1aa9ac167c1e3e727930d6"
+           "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4"
           ],
           "threshold": 1
          },
          "snapshot": {
           "keyids": [
-           "fce9cf1cc86b0945d6a042f334026f31ed8e4ee1510218f198e8d3f191d15309"
+           "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc"
           ],
           "threshold": 1
          },
          "targets": {
           "keyids": [
-           "93ec2c3dec7cc08922179320ccd8c346234bf7f21705268b93e990d5273a2a3b"
+           "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164"
           ],
           "threshold": 1
          },
          "timestamp": {
           "keyids": [
-           "1a2b4110927d4cba257262f614896179ff85ca1f1353a41b5224ac474ca71cb4"
+           "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
           ],
           "threshold": 1
          }
@@ -719,7 +719,7 @@ repo](https://github.com/theupdateframework/specification/issues).
        {
        "signatures": [
         {
-         "keyid": "fce9cf1cc86b0945d6a042f334026f31ed8e4ee1510218f198e8d3f191d15309",
+         "keyid": "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc",
          "sig": "f7f03b13e3f4a78a23561419fc0dd741a637e49ee671251be9f8f3fceedfc112e4
                  4ee3aaff2278fad9164ab039118d4dc53f22f94900dae9a147aa4d35dcfc0f"
         }
@@ -850,7 +850,7 @@ repo](https://github.com/theupdateframework/specification/issues).
        {
        "signatures": [
         {
-         "keyid": "93ec2c3dec7cc08922179320ccd8c346234bf7f21705268b93e990d5273a2a3b",
+         "keyid": "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164",
          "sig": "e9fd40008fba263758a3ff1dc59f93e42a4910a282749af915fbbea1401178e5a0
                  12090c228f06db1deb75ad8ddd7e40635ac51d4b04301fce0fd720074e0209"
         }
@@ -860,7 +860,7 @@ repo](https://github.com/theupdateframework/specification/issues).
         "spec_version": "1",
         "delegations": {
          "keys": {
-          "ce3e02e72980b09ca6f5efa68197130b381921e5d0675e2e0c8f3c47e0626bba": {
+          "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6": {
            "keytype": "ed25519",
            "scheme": "ed25519",
            "keyval": {
@@ -871,7 +871,7 @@ repo](https://github.com/theupdateframework/specification/issues).
          "roles": [
           {
            "keyids": [
-            "ce3e02e72980b09ca6f5efa68197130b381921e5d0675e2e0c8f3c47e0626bba"
+            "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6"
            ],
            "name": "project",
            "paths": [
@@ -928,7 +928,7 @@ repo](https://github.com/theupdateframework/specification/issues).
        {
        "signatures": [
         {
-         "keyid": "1a2b4110927d4cba257262f614896179ff85ca1f1353a41b5224ac474ca71cb4",
+         "keyid": "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3",
          "sig": "90d2a06c7a6c2a6a93a9f5771eb2e5ce0c93dd580bebc2080d10894623cfd6eaed
                  f4df84891d5aa37ace3ae3736a698e082e12c300dfe5aee92ea33a8f461f02"
         }


### PR DESCRIPTION
It looks like the sample Key IDs in the 1.0 spec were not updated to the TUF 1.0 algorithm. For example:

```python
>>> key_meta = { "keytype": "ed25519", "keyval": { "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c" } }
>>> key_update_data = securesystemslib.formats.encode_canonical(key_meta)
>>> digest_object = securesystemslib.hash.digest("sha256")
>>> digest_object.update(key_update_data.encode('utf-8'))
>>> digest_object.hexdigest()
'1a2b4110927d4cba257262f614896179ff85ca1f1353a41b5224ac474ca71cb4'
>>>
>>> key_meta = { "keytype": "ed25519", "scheme": "ed25519", "keyval": { "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c" } }
>>> key_update_data = securesystemslib.formats.encode_canonical(key_meta)
>>> digest_object = securesystemslib.hash.digest("sha256")
>>> digest_object.update(key_update_data.encode('utf-8'))
>>> digest_object.hexdigest()
'1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3'
```

This updates the keys to be calculated with the new algorithm, which includes the `"method"` in the key metadata.

edit: I was wrong, all the key ids were using the old algorithm. I updated this PR to also rewrite those key ids.