### PR TITLE
Use hex encoding is used for ed25519 and target hashes

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -475,7 +475,8 @@ repo](https://github.com/theupdateframework/specification/issues).
 
           KEYID is the identifier of the key signing the ROLE dictionary.
 
-          SIGNATURE is a signature of the canonical JSON form of ROLE.
+          SIGNATURE is a hex-encoded signature of the canonical JSON form of
+          ROLE.
 
 
    All keys have the format:
@@ -532,7 +533,9 @@ repo](https://github.com/theupdateframework/specification/issues).
           "keyval" : {"public" : PUBLIC}
         }
 
-   where PUBLIC is a 32-byte string.
+   where:
+
+          PUBLIC is a 64-byte hex encoded string.
 
    The 'ecdsa' format is:
 
@@ -769,6 +772,11 @@ repo](https://github.com/theupdateframework/specification/issues).
 
    It is allowed to have a TARGETS object with no TARGETPATH elements.  This
    can be used to indicate that no target files are available.
+
+   HASHES is a dictionary that specifies one or more hashes, including
+   the cryptographic hash function.  For example: { "sha256": HASH, ... }. It
+   is required for delegated roles, and optional for all others. HASH is the
+   hexdigest of the cryptographic function computed on the target file.
 
    If defined, the elements and values of "custom" will be made available to the
    client application.  The information in "custom" is opaque to the framework


### PR DESCRIPTION
According to #42, the spec should explicitly state that the ed25519 public key, and the target hash values are hex encoded values, since that is used by the majority of tuf implementations.

Closes #42