### PR TITLE
timestamp must only refer to the snapshot metadata

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -928,8 +928,8 @@ repo](https://github.com/theupdateframework/specification/issues).
        }
 
    METAFILES is the same is described for the snapshot.json file.  In the case
-   of the timestamp.json file, this will commonly only include a description of
-   the snapshot.json file.
+   of the timestamp.json file, this MUST only include a description of the
+   snapshot.json file.
 
    A signed timestamp.json example file:
 


### PR DESCRIPTION
@JustinCappos in https://github.com/heartsucker/rust-tuf/pull/207#issuecomment-521453860 recommended that the timestamp role should only allow a reference to the snapshot metadata, and no other roles.