### PR TITLE
delegated targets are authorized by keys in the delegating target roles

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -462,6 +462,9 @@ repo](https://github.com/theupdateframework/specification/issues).
 
     /ANOTHER_ROLE.json
 
+   Delegated target roles are authorized by the keys listed in the directly
+   delegating target role.
+
 ## **4. Document formats**
 
    All of the formats described below include the ability to add more
@@ -836,6 +839,10 @@ repo](https://github.com/theupdateframework/specification/issues).
              "terminating": TERMINATING,
          }, ... ]
        }
+
+   "keys" lists the public keys to verify signatures of delegated targets roles.
+   Revocation and replacement of delegated targets roles keys is done by
+   changing the keys in this field in the delegating role's metadata.
 
    ROLENAME is the name of the delegated role.  For example,
    "projects".


### PR DESCRIPTION
This extends the spec to clarify that when searching for the key that
signed a delegated role, that key should only be found in the delegating
target, and not any other role in the delegation chain. This incorporates
language suggested by lukpueh in #58, and the definition of the keys
field from [TAP 3](#57).

Closes #58