### PR TITLE
Fix (delegated) targets metadata HASHES definition

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -813,10 +813,9 @@ repo](https://github.com/theupdateframework/specification/issues).
    It is allowed to have a TARGETS object with no TARGETPATH elements.  This
    can be used to indicate that no target files are available.
 
-   HASHES is a dictionary that specifies one or more hashes, including
-   the cryptographic hash function.  For example: { "sha256": HASH, ... }. It
-   is required for delegated roles, and optional for all others. HASH is the
-   hexdigest of the cryptographic function computed on the target file.
+   HASHES is a dictionary that specifies one or more hashes, including the
+   cryptographic hash function.  For example: { "sha256": HASH, ... }. HASH is
+   the hexdigest of the cryptographic function computed on the target file.
 
    If defined, the elements and values of "custom" will be made available to the
    client application.  The information in "custom" is opaque to the framework


### PR DESCRIPTION
Remove not fully accurate phrase in the `HASHES` definition in section “4.5. File formats: targets.json and delegated target roles” of the spec.

Contrary to that phrase, `HASHES` is an unconditionally mandatory value under each `TARGETPATH` for top-level targets and all delegated targets roles:
```
 { TARGETPATH : {
       "length" : LENGTH,
       "hashes" : HASHES,
       ("custom" : { ... }) }
   , ...
 }
```

It seems like this accidentally slipped through our review in the recent (and actually unrelated) #47. (cc @erickt, @trishankatdatadog).