### PR TITLE
Remove problematic targets rollback attack check

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1214,42 +1214,36 @@ non-volatile storage as FILENAME.EXT.
   trusted root metadata file.  If the new targets metadata file is not signed
   as required, discard it, abort the update cycle, and report the failure.
 
-  * **4.3**. **Check for a rollback attack.** The version number of the trusted
-  targets metadata file, if any, MUST be less than or equal to the version
-  number of the new targets metadata file.  If the new targets metadata file is
-  older than the trusted targets metadata file, discard it, abort the update
-  cycle, and report the potential rollback attack.
-
-  * **4.4**. **Check for a freeze attack.** The latest known time should be
+  * **4.3**. **Check for a freeze attack.** The latest known time should be
   lower than the expiration timestamp in the new targets metadata file.  If so,
   the new targets metadata file becomes the trusted targets metadata file.  If
   the new targets metadata file is expired, discard it, abort the update cycle,
   and report the potential freeze attack.
 
-  * **4.5**. **Perform a preorder depth-first search for metadata about the
+  * **4.4**. **Perform a preorder depth-first search for metadata about the
   desired target, beginning with the top-level targets role.**  Note: If
-  any metadata requested in steps 4.5.1 - 4.5.2.3 cannot be downloaded nor
+  any metadata requested in steps 4.4.1 - 4.4.2.3 cannot be downloaded nor
   validated, end the search and report that the target cannot be found.
 
-    * **4.5.1**. If this role has been visited before, then skip this role (so
+    * **4.4.1**. If this role has been visited before, then skip this role (so
     that cycles in the delegation graph are avoided).  Otherwise, if an
     application-specific maximum number of roles have been visited, then go to
     step 5 (so that attackers cannot cause the client to waste excessive
     bandwidth or time).  Otherwise, if this role contains metadata about the
     desired target, then go to step 5.
 
-    * **4.5.2**. Otherwise, recursively search the list of delegations in order
+    * **4.4.2**. Otherwise, recursively search the list of delegations in order
     of appearance.
 
-      * **4.5.2.1**. If the current delegation is a multi-role delegation,
+      * **4.4.2.1**. If the current delegation is a multi-role delegation,
       recursively visit each role, and check that each has signed exactly the
       same non-custom metadata (i.e., length and hashes) about the target (or
       the lack of any such metadata).
 
-      * **4.5.2.2**. If the current delegation is a terminating delegation,
+      * **4.4.2.2**. If the current delegation is a terminating delegation,
       then jump to step 5.
 
-      * **4.5.2.3**. Otherwise, if the current delegation is a non-terminating
+      * **4.4.2.3**. Otherwise, if the current delegation is a non-terminating
       delegation, continue processing the next delegation, if any. Stop the
       search, and jump to step 5 as soon as a delegation returns a result.
 


### PR DESCRIPTION
In the client application workflow, remove rollback attack check for top-level targets file, which is (1) redundant and (2) prevents recovery from a fast-forward attack.

(1) rollback attacks, via serving older versions of targets or top-level targets than the previously trusted versions, are already prevented by step 3.3.3 of the client workflow, where version numbers of targets and delegated targets in the new snapshot metadata are asserted to be greater than those in the prior trusted snapshot metadata. This, in combination with the 4.1 check that asserts that hashes and version of the actual targets metadata match the ones in the new trusted snapshot, makes another version number check, i.e the one removed in this PR, obsolete.

(2) fast-forward attack recovery, as described in 1.9, works by having the client remove the trusted timestamp and snapshot metadata after a non-root key rotation, so that the client can overcome the version comparison check, and update from a compromised high version to a recovered lower version. However, 1.9 does not mention removing trusted targets metadata after a key rotation. As a consequence, the additional version number check, removed in this PR, would prevent updating recovered targets metadata after a fast-forward attack.