### PR TITLE
Add example for downloading foo/bar/baz target files

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1265,10 +1265,12 @@ non-volatile storage as FILENAME.EXT.
   external program is used to compute the root hash of a tree of targets files,
   and this program does not provide the total size of all of these files.) If
   consistent snapshots are not used (see Section 7), then the filename used to
-  download the target file is of the fixed form FILENAME.EXT (e.g.,
-  foobar.tar.gz).  Otherwise, the filename is of the form HASH.FILENAME.EXT
+  download the target file is of the fixed form PATH/TO/FILENAME.EXT (e.g.,
+  foobar.tar.gz or baz/foo/bar).  Otherwise, the filename is of the form
+  PATH/TO/HASH.FILENAME.EXT
   (e.g.,
-  c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681.foobar.tar.gz),
+  c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681.foobar.tar.gz
+  or foo/bar/c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681.baz),
   where HASH is one of the hashes of the targets file listed in the targets
   metadata file found earlier in step 4.  In either case, the client MUST write
   the file to non-volatile storage as FILENAME.EXT.


### PR DESCRIPTION
This extends section 5.5.2 to include examples on how a client should download artifacts from a subdirectory. It uses the approach that python-tuf and go-tuf use, where downloading a target path like `path/to/file.ext` when consistent snapshots are enabled are fetched from `path/to/$HASH.file.ext`.