### PR TITLE
Clarify rollback attack prevention and fast-forward attack recovery

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1220,14 +1220,13 @@ non-volatile storage as FILENAME.EXT.
     metadata file, discard it, abort the update cycle, and report the potential
     rollback attack.
 
-    * **3.3.2**. The version number of the targets metadata file, and all
-    delegated targets metadata files (if any), in the trusted snapshot metadata
-    file, if any, MUST be less than or equal to its version number in the new
-    snapshot metadata file. Furthermore, any targets metadata filename that was
-    listed in the trusted snapshot metadata file, if any, MUST continue to be
-    listed in the new snapshot metadata file.  If any of these conditions are
-    not met, discard the new snapshot metadadata file, abort the update cycle,
-    and report the failure.
+    * **3.3.2**. The version number of the top-level targets metadata file, in
+    the trusted snapshot metadata file, if any, MUST be less than or equal to
+    its version number in the new snapshot metadata file. Furthermore, any
+    targets metadata filename that was listed in the trusted snapshot metadata
+    file, if any, MUST continue to be listed in the new snapshot metadata file.
+    If any of these conditions are not met, discard the new snapshot metadadata
+    file, abort the update cycle, and report the failure.
 
   * **3.4**. **Check for a freeze attack.** The latest known time should be
   lower than the expiration timestamp in the new snapshot metadata file.  If
@@ -1287,7 +1286,18 @@ non-volatile storage as FILENAME.EXT.
       * **4.5.2.1**. Let DELEGATE denote the current target role TARGETS is
       delegating to.
 
-      * **4.5.2.2**. **Download the DELEGATE targets metadata file**, up to either
+      * **4.5.2.2**. **Fast-forward attack recovery.** If a threshold of
+      delegated targets keys for the current delegation are removed from the
+      TARGETS metadata, delete the trusted DELEGATE metadata, if any, and the
+      previously trusted snapshot metadata.
+
+      * **4.5.2.3**. **Check for a rollback attack via snapshot.** The version number of the
+      DELEGATE metadata in the previous trusted snapshot metadata, if any, MUST
+      be less than or equal to its version number in the new trusted snapshot
+      metadata. If this is not the case, abort the update cycle, and report the
+      potential rollback attack.
+
+      * **4.5.2.4**. **Download the DELEGATE targets metadata file**, up to either
       the number of bytes specified in the snapshot metadata file, or some Z
       number of bytes. The value for Z is set by the authors of the application
       using TUF. For example, Z may be tens of kilobytes. IF DELEGATE cannot be
@@ -1300,39 +1310,40 @@ non-volatile storage as FILENAME.EXT.
       in the snapshot metadata file.  In either case, the client MUST write the
       file to non-volatile storage as FILENAME.EXT.
 
-      * **4.5.2.3**. **Check against snapshot metadata.** The hashes (if any), and
+      * **4.5.2.5**. **Check against snapshot metadata.** The hashes (if any), and
       version number of the new DELEGATE metadata file MUST match the trusted
-      snapshot metadata.  This is done, in part, to prevent a mix-and-match
+      snapshot metadata, if any.  This is done, in part, to prevent a mix-and-match
       attack by man-in-the-middle attackers. If the new DELEGATE metadata file
       does not match, abort the update cycle, and report the failure.
 
-      * **4.5.2.4**. **Check for an arbitrary software attack.** The new DELEGATE
+      * **4.5.2.6**. **Check for an arbitrary software attack.** The new DELEGATE
       metadata file MUST have been signed by a threshold of keys specified in the
       TARGETS metadata file.  If the new DELEGATE metadata file is not signed
       as required, abort the update cycle, and report the failure.
 
-      * **4.5.2.5**. **Check for a rollback attack.** The version number of the
-      trusted DELEGATE metadata file, if any, MUST be less than or equal to the
-      version number of the new DELEGATE metadata file.  If the new DELEGATE
-      metadata file is older than the trusted DELEGATE metadata file, discard
-      it, abort the update cycle, and report the potential rollback attack.
+      * **4.5.2.7**. **Check for a rollback attack on the DELEGATE metadata.**
+      The version number of the trusted DELEGATE metadata file, if any, MUST be
+      less than or equal to the version number of the new DELEGATE metadata
+      file.  If the new DELEGATE metadata file is older than the trusted
+      DELEGATE metadata file abort the update cycle, and report the potential
+      rollback attack.
 
-      * **4.5.2.6**. **Check for a freeze attack.** The latest known time
+      * **4.5.2.8**. **Check for a freeze attack.** The latest known time
       should be lower than the expiration timestamp in the new DELEGATE
       metadata file. If so, the new DELEGATE file becomes the trusted DELEGATE
       file. If the new DELEGATE metadata file is expired, abort the update
       cycle, and report the potential freeze attack.
 
-      * **4.5.2.7**. If the current delegation is a multi-role delegation,
+      * **4.5.2.9**. If the current delegation is a multi-role delegation,
       recursively visit each role, and check that each has signed exactly the
       same non-custom metadata (i.e., length and hashes) about the target (or
       the lack of any such metadata). Otherwise, abort the update cycle, and
       report the failure.
 
-      * **4.5.2.8**. If the current delegation is a terminating delegation,
+      * **4.5.2.10**. If the current delegation is a terminating delegation,
       then jump to step 5.
 
-      * **4.5.2.9**. Otherwise, if the current delegation is a non-terminating
+      * **4.5.2.11**. Otherwise, if the current delegation is a non-terminating
       delegation, continue processing the next delegation, if any, by repeating
       step 4.5 with DELEGATE as the current TARGET role. Stop the search, and
       jump to step 5 as soon as a delegation returns a result.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1274,14 +1274,14 @@ non-volatile storage as FILENAME.EXT.
       * **4.5.2.1**. Let DELEGATE denote the current target role TARGETS is
       delegating to.
 
-      * **4.5.2.2**. **Download the DELEGATE tarets metadata file**, up to either
+      * **4.5.2.2**. **Download the DELEGATE targets metadata file**, up to either
       the number of bytes specified in the snapshot metadata file, or some Z
       number of bytes. The value for Z is set by the authors of the application
       using TUF. For example, Z may be tens of kilobytes. IF DELEGATE cannot be
       found, end the search and report the target cannot be found.  If
       consistent snapshots are not used (see Section 7), then the filename used
       to download the targets metadata file is of the fixed form FILENAME.EXT
-      (e.g., delegated_rol.json).  Otherwise, the filename is of the form
+      (e.g., delegated_role.json).  Otherwise, the filename is of the form
       VERSION_NUMBER.FILENAME.EXT (e.g., 42.delegated_role.json), where
       VERSION_NUMBER is the version number of the DELEGATE metadata file listed
       in the snapshot metadata file.  In either case, the client MUST write the
@@ -1303,7 +1303,7 @@ non-volatile storage as FILENAME.EXT.
       * **4.5.2.5**. **Check for a rollback attack.** The version number of the
       trusted DELEGATE metadata file, if any, MUST be less than or equal to the
       version number of the new DELEGATE metadata file.  If the new DELEGATE
-      `metadata file is older than the trusted DELEGATE metadata file, discard
+      metadata file is older than the trusted DELEGATE metadata file, discard
       it, end the search, and report the target cannot be found.
 
       * **4.5.2.6**. If the current delegation is a multi-role delegation,

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1135,12 +1135,15 @@ repo](https://github.com/theupdateframework/specification/issues).
 
   * **1.9**. **Fast-forward attack recovery** A _fast-forward attack_ happens
   when attackers arbitrarily increase the version numbers in any of the
-  timestamp, snapshot, targets, or delegated targets metadata. To recover from
+  timestamp, snapshot, targets, or delegated targets metadata. The attacker goal
+  is to cause clients to refuse to update the metadata later because the attacker's
+  listed metadata version number (possibly MAX_INT) is greater than the new valid 
+  version.  To recover from
   fast-forward attacks after the repository has been compromised and recovered,
   certain metadata files need to be deleted as specified in this section.
   Please see [the Mercury
   paper](https://ssl.engineering.nyu.edu/papers/kuppusamy-mercury-usenix-2017.pdf)
-  for more details.
+  for more details on fast-forward attacks.
 
     * **1.9.1**. **Targets recovery** If a threshold of targets keys have been
     removed in the new trusted root metadata compared to the previous trusted

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1142,9 +1142,10 @@ repo](https://github.com/theupdateframework/specification/issues).
   paper](https://ssl.engineering.nyu.edu/papers/kuppusamy-mercury-usenix-2017.pdf)
   for more details.
 
-    * **1.9.1**. **Targets recovery** If a threshold of targets keys are removed
-    from the root metadata, delete the old top-level targets, snapshot, and
-    timestamp metadata files.
+    * **1.9.1**. **Targets recovery** If a threshold of targets keys have been
+    removed in the new trusted root metadata compared to the previous trusted
+    root metadata, delete the old top-level targets and snapshot metadata
+    files.
 
     * **1.9.2**. **Snapshot recovery** If a threshold of snapshot keys have
     been removed in the new trusted root metadata compared to the previous

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1306,16 +1306,22 @@ non-volatile storage as FILENAME.EXT.
       metadata file is older than the trusted DELEGATE metadata file, discard
       it, end the search, and report the target cannot be found.
 
-      * **4.5.2.6**. If the current delegation is a multi-role delegation,
+      * **4.5.2.6**. **Check for a freeze attack.** The latest known time
+      should be lower than the expiration timestamp in the new DELEGATE
+      metadata file. If so, the new DELEGATE file becomes the trusted DELEGATE
+      file. If the new DELEGATE metadata file is expired, discard it, end the
+      search, and report the target cannot be found.
+
+      * **4.5.2.7**. If the current delegation is a multi-role delegation,
       recursively visit each role, and check that each has signed exactly the
       same non-custom metadata (i.e., length and hashes) about the target (or
       the lack of any such metadata). Otherwise, discard it, end the search,
       and report the target cannot be found.
 
-      * **4.5.2.7**. If the current delegation is a terminating delegation,
+      * **4.5.2.8**. If the current delegation is a terminating delegation,
       then jump to step 5.
 
-      * **4.5.2.8**. Otherwise, if the current delegation is a non-terminating
+      * **4.5.2.9**. Otherwise, if the current delegation is a non-terminating
       delegation, continue processing the next delegation, if any, by repeating
       step 4.5 with DELEGATE as the current TARGET role. Stop the search, and
       jump to step 5 as soon as a delegation returns a result.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1258,9 +1258,8 @@ non-volatile storage as FILENAME.EXT.
   and report the potential freeze attack.
 
   * **4.5**. **Perform a preorder depth-first search for metadata about the
-  desired target, beginning with the top-level targets role.**  Note: If
-  any metadata requested in steps 4.5.1 - 4.5.2.3 cannot be downloaded nor
-  validated, end the search and report that the target cannot be found.
+  desired target.** Let TARGETS be the current metadata, beginning with the
+  top-level targets metadata role.
 
     * **4.5.1**. If this role has been visited before, then skip this role (so
     that cycles in the delegation graph are avoided).  Otherwise, if an
@@ -1272,17 +1271,54 @@ non-volatile storage as FILENAME.EXT.
     * **4.5.2**. Otherwise, recursively search the list of delegations in order
     of appearance.
 
-      * **4.5.2.1**. If the current delegation is a multi-role delegation,
+      * **4.5.2.1**. Let DELEGATE denote the current target role TARGETS is
+      delegating to.
+
+      * **4.5.2.2**. **Download the DELEGATE tarets metadata file**, up to either
+      the number of bytes specified in the snapshot metadata file, or some Z
+      number of bytes. The value for Z is set by the authors of the application
+      using TUF. For example, Z may be tens of kilobytes. IF DELEGATE cannot be
+      found, end the search and report the target cannot be found.  If
+      consistent snapshots are not used (see Section 7), then the filename used
+      to download the targets metadata file is of the fixed form FILENAME.EXT
+      (e.g., delegated_rol.json).  Otherwise, the filename is of the form
+      VERSION_NUMBER.FILENAME.EXT (e.g., 42.delegated_role.json), where
+      VERSION_NUMBER is the version number of the DELEGATE metadata file listed
+      in the snapshot metadata file.  In either case, the client MUST write the
+      file to non-volatile storage as FILENAME.EXT.
+
+      * **4.5.2.3**. **Check against snapshot metadata.** The hashes (if any), and
+      version number of the new DELEGATE metadata file MUST match the trusted
+      snapshot metadata.  This is done, in part, to prevent a mix-and-match
+      attack by man-in-the-middle attackers. If the new DELEGATE metadata file
+      does not match, discard it, end the search, and report the target cannot
+      be found.
+
+      * **4.5.2.4**. **Check for an arbitrary software attack.** The new DELEGATE
+      metadata file MUST have been signed by a threshold of keys specified in the
+      TARGETS metadata file.  If the new DELEGATE metadata file is not signed
+      as required, discard it, end the search, and report the target cannot be
+      found.
+
+      * **4.5.2.5**. **Check for a rollback attack.** The version number of the
+      trusted DELEGATE metadata file, if any, MUST be less than or equal to the
+      version number of the new DELEGATE metadata file.  If the new DELEGATE
+      `metadata file is older than the trusted DELEGATE metadata file, discard
+      it, end the search, and report the target cannot be found.
+
+      * **4.5.2.6**. If the current delegation is a multi-role delegation,
       recursively visit each role, and check that each has signed exactly the
       same non-custom metadata (i.e., length and hashes) about the target (or
-      the lack of any such metadata).
+      the lack of any such metadata). Otherwise, discard it, end the search,
+      and report the target cannot be found.
 
-      * **4.5.2.2**. If the current delegation is a terminating delegation,
+      * **4.5.2.7**. If the current delegation is a terminating delegation,
       then jump to step 5.
 
-      * **4.5.2.3**. Otherwise, if the current delegation is a non-terminating
-      delegation, continue processing the next delegation, if any. Stop the
-      search, and jump to step 5 as soon as a delegation returns a result.
+      * **4.5.2.8**. Otherwise, if the current delegation is a non-terminating
+      delegation, continue processing the next delegation, if any, by repeating
+      step 4.5 with DELEGATE as the current TARGET role. Stop the search, and
+      jump to step 5 as soon as a delegation returns a result.
 
 **5**. **Verify the desired target against its targets metadata**.
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1291,32 +1291,30 @@ non-volatile storage as FILENAME.EXT.
       version number of the new DELEGATE metadata file MUST match the trusted
       snapshot metadata.  This is done, in part, to prevent a mix-and-match
       attack by man-in-the-middle attackers. If the new DELEGATE metadata file
-      does not match, discard it, end the search, and report the target cannot
-      be found.
+      does not match, abort the update cycle, and report the failure.
 
       * **4.5.2.4**. **Check for an arbitrary software attack.** The new DELEGATE
       metadata file MUST have been signed by a threshold of keys specified in the
       TARGETS metadata file.  If the new DELEGATE metadata file is not signed
-      as required, discard it, end the search, and report the target cannot be
-      found.
+      as required, abort the update cycle, and report the failure.
 
       * **4.5.2.5**. **Check for a rollback attack.** The version number of the
       trusted DELEGATE metadata file, if any, MUST be less than or equal to the
       version number of the new DELEGATE metadata file.  If the new DELEGATE
       metadata file is older than the trusted DELEGATE metadata file, discard
-      it, end the search, and report the target cannot be found.
+      it, abort the update cycle, and report the potential rollback attack.
 
       * **4.5.2.6**. **Check for a freeze attack.** The latest known time
       should be lower than the expiration timestamp in the new DELEGATE
       metadata file. If so, the new DELEGATE file becomes the trusted DELEGATE
-      file. If the new DELEGATE metadata file is expired, discard it, end the
-      search, and report the target cannot be found.
+      file. If the new DELEGATE metadata file is expired, abort the update
+      cycle, and report the potential freeze attack.
 
       * **4.5.2.7**. If the current delegation is a multi-role delegation,
       recursively visit each role, and check that each has signed exactly the
       same non-custom metadata (i.e., length and hashes) about the target (or
-      the lack of any such metadata). Otherwise, discard it, end the search,
-      and report the target cannot be found.
+      the lack of any such metadata). Otherwise, abort the update cycle, and
+      report the failure.
 
       * **4.5.2.8**. If the current delegation is a terminating delegation,
       then jump to step 5.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1148,7 +1148,10 @@ repo](https://github.com/theupdateframework/specification/issues).
     * **1.9.1**. **Targets recovery** If a threshold of targets keys have been
     removed in the new trusted root metadata compared to the previous trusted
     root metadata, delete the old top-level targets and snapshot metadata
-    files.
+    files. Note that delegated targets are suceptible to fast forward attacks,
+    because snapshot must be checked before a key rotation in the delegating
+    target role is known to the client. To fix this, nuke delegation or make
+    repository rotate the the snapshot key.
 
     * **1.9.2**. **Snapshot recovery** If a threshold of snapshot keys have
     been removed in the new trusted root metadata compared to the previous
@@ -1223,9 +1226,9 @@ non-volatile storage as FILENAME.EXT.
     metadata file, discard it, abort the update cycle, and report the potential
     rollback attack.
 
-    * **3.3.2**. The version number of the top-level targets metadata file, in
+    * **3.3.2**. The version number of all targets metadata files in
     the trusted snapshot metadata file, if any, MUST be less than or equal to
-    its version number in the new snapshot metadata file. Furthermore, any
+    their version numbers in the new snapshot metadata file. Furthermore, any
     targets metadata filename that was listed in the trusted snapshot metadata
     file, if any, MUST continue to be listed in the new snapshot metadata file.
     If any of these conditions are not met, discard the new snapshot metadadata
@@ -1289,18 +1292,7 @@ non-volatile storage as FILENAME.EXT.
       * **4.5.2.1**. Let DELEGATEE denote the current target role TARGETS is
       delegating to.
 
-      * **4.5.2.2**. **Fast-forward attack recovery.** If a threshold of
-      delegated targets keys for the current delegation are removed from the
-      TARGETS metadata, delete the trusted DELEGATEE metadata, if any, and the
-      previously trusted snapshot metadata.
-
-      * **4.5.2.3**. **Check for a rollback attack via snapshot.** The version number of the
-      DELEGATEE metadata in the previous trusted snapshot metadata, if any, MUST
-      be less than or equal to its version number in the new trusted snapshot
-      metadata. If this is not the case, abort the update cycle, and report the
-      potential rollback attack.
-
-      * **4.5.2.4**. **Download the DELEGATEE targets metadata file**, up to either
+      * **4.5.2.2**. **Download the DELEGATEE targets metadata file**, up to either
       the number of bytes specified in the snapshot metadata file, or some Z
       number of bytes. The value for Z is set by the authors of the application
       using TUF. For example, Z may be tens of kilobytes. IF DELEGATEE cannot be
@@ -1313,41 +1305,41 @@ non-volatile storage as FILENAME.EXT.
       in the snapshot metadata file.  In either case, the client MUST write the
       file to non-volatile storage as FILENAME.EXT.
 
-      * **4.5.2.5**. **Check against snapshot metadata.**  The hashes and
+      * **4.5.2.3**. **Check against snapshot metadata.**  The hashes and
       version number of the new DELEGATEE metadata file MUST match the hashes
       (if any) and version number listed in the trusted snapshot metadata. This
       is done, in part, to prevent a mix-and-match attack by man-in-the-middle
       attackers. If the new DELEGATEE metadata file does not match, abort the
       update cycle, and report the failure.
 
-      * **4.5.2.6**. **Check for an arbitrary software attack.** The new DELEGATEE
+      * **4.5.2.4**. **Check for an arbitrary software attack.** The new DELEGATEE
       metadata file MUST have been signed by a threshold of keys specified in the
       TARGETS metadata file.  If the new DELEGATEE metadata file is not signed
       as required, abort the update cycle, and report the failure.
 
-      * **4.5.2.7**. **Check for a rollback attack on the DELEGATEE metadata.**
+      * **4.5.2.5**. **Check for a rollback attack.**
       The version number of the trusted DELEGATEE metadata file, if any, MUST be
       less than or equal to the version number of the new DELEGATEE metadata
       file.  If the new DELEGATEE metadata file is older than the trusted
       DELEGATEE metadata file abort the update cycle, and report the potential
       rollback attack.
 
-      * **4.5.2.8**. **Check for a freeze attack.** The latest known time
+      * **4.5.2.6**. **Check for a freeze attack.** The latest known time
       should be lower than the expiration timestamp in the new DELEGATEE
       metadata file. If so, the new DELEGATEE file becomes the trusted DELEGATEE
       file. If the new DELEGATEE metadata file is expired, abort the update
       cycle, and report the potential freeze attack.
 
-      * **4.5.2.9**. If the current delegation is a multi-role delegation,
+      * **4.5.2.7**. If the current delegation is a multi-role delegation,
       recursively visit each role, and check that each has signed exactly the
       same non-custom metadata (i.e., length and hashes) about the target (or
       the lack of any such metadata). Otherwise, abort the update cycle, and
       report the failure.
 
-      * **4.5.2.10**. If the current delegation is a terminating delegation,
+      * **4.5.2.8**. If the current delegation is a terminating delegation,
       then jump to step 5.
 
-      * **4.5.2.11**. Otherwise, if the current delegation is a non-terminating
+      * **4.5.2.9**. Otherwise, if the current delegation is a non-terminating
       delegation, continue processing the next delegation, if any, by repeating
       step 4.5 with DELEGATEE as the current TARGET role. Stop the search, and
       jump to step 5 as soon as a delegation returns a result.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1245,36 +1245,42 @@ non-volatile storage as FILENAME.EXT.
   trusted root metadata file.  If the new targets metadata file is not signed
   as required, discard it, abort the update cycle, and report the failure.
 
-  * **4.3**. **Check for a freeze attack.** The latest known time should be
+  * **4.3**. **Check for a rollback attack.** The version number of the trusted
+  targets metadata file, if any, MUST be less than or equal to the version
+  number of the new targets metadata file.  If the new targets metadata file is
+  older than the trusted targets metadata file, discard it, abort the update
+  cycle, and report the potential rollback attack.
+
+  * **4.4**. **Check for a freeze attack.** The latest known time should be
   lower than the expiration timestamp in the new targets metadata file.  If so,
   the new targets metadata file becomes the trusted targets metadata file.  If
   the new targets metadata file is expired, discard it, abort the update cycle,
   and report the potential freeze attack.
 
-  * **4.4**. **Perform a preorder depth-first search for metadata about the
+  * **4.5**. **Perform a preorder depth-first search for metadata about the
   desired target, beginning with the top-level targets role.**  Note: If
-  any metadata requested in steps 4.4.1 - 4.4.2.3 cannot be downloaded nor
+  any metadata requested in steps 4.5.1 - 4.5.2.3 cannot be downloaded nor
   validated, end the search and report that the target cannot be found.
 
-    * **4.4.1**. If this role has been visited before, then skip this role (so
+    * **4.5.1**. If this role has been visited before, then skip this role (so
     that cycles in the delegation graph are avoided).  Otherwise, if an
     application-specific maximum number of roles have been visited, then go to
     step 5 (so that attackers cannot cause the client to waste excessive
     bandwidth or time).  Otherwise, if this role contains metadata about the
     desired target, then go to step 5.
 
-    * **4.4.2**. Otherwise, recursively search the list of delegations in order
+    * **4.5.2**. Otherwise, recursively search the list of delegations in order
     of appearance.
 
-      * **4.4.2.1**. If the current delegation is a multi-role delegation,
+      * **4.5.2.1**. If the current delegation is a multi-role delegation,
       recursively visit each role, and check that each has signed exactly the
       same non-custom metadata (i.e., length and hashes) about the target (or
       the lack of any such metadata).
 
-      * **4.4.2.2**. If the current delegation is a terminating delegation,
+      * **4.5.2.2**. If the current delegation is a terminating delegation,
       then jump to step 5.
 
-      * **4.4.2.3**. Otherwise, if the current delegation is a non-terminating
+      * **4.5.2.3**. Otherwise, if the current delegation is a non-terminating
       delegation, continue processing the next delegation, if any. Stop the
       search, and jump to step 5 as soon as a delegation returns a result.
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1286,55 +1286,55 @@ non-volatile storage as FILENAME.EXT.
     * **4.5.2**. Otherwise, recursively search the list of delegations in order
     of appearance.
 
-      * **4.5.2.1**. Let DELEGATE denote the current target role TARGETS is
+      * **4.5.2.1**. Let DELEGATEE denote the current target role TARGETS is
       delegating to.
 
       * **4.5.2.2**. **Fast-forward attack recovery.** If a threshold of
       delegated targets keys for the current delegation are removed from the
-      TARGETS metadata, delete the trusted DELEGATE metadata, if any, and the
+      TARGETS metadata, delete the trusted DELEGATEE metadata, if any, and the
       previously trusted snapshot metadata.
 
       * **4.5.2.3**. **Check for a rollback attack via snapshot.** The version number of the
-      DELEGATE metadata in the previous trusted snapshot metadata, if any, MUST
+      DELEGATEE metadata in the previous trusted snapshot metadata, if any, MUST
       be less than or equal to its version number in the new trusted snapshot
       metadata. If this is not the case, abort the update cycle, and report the
       potential rollback attack.
 
-      * **4.5.2.4**. **Download the DELEGATE targets metadata file**, up to either
+      * **4.5.2.4**. **Download the DELEGATEE targets metadata file**, up to either
       the number of bytes specified in the snapshot metadata file, or some Z
       number of bytes. The value for Z is set by the authors of the application
-      using TUF. For example, Z may be tens of kilobytes. IF DELEGATE cannot be
+      using TUF. For example, Z may be tens of kilobytes. IF DELEGATEE cannot be
       found, end the search and report the target cannot be found.  If
       consistent snapshots are not used (see Section 7), then the filename used
       to download the targets metadata file is of the fixed form FILENAME.EXT
       (e.g., delegated_role.json).  Otherwise, the filename is of the form
       VERSION_NUMBER.FILENAME.EXT (e.g., 42.delegated_role.json), where
-      VERSION_NUMBER is the version number of the DELEGATE metadata file listed
+      VERSION_NUMBER is the version number of the DELEGATEE metadata file listed
       in the snapshot metadata file.  In either case, the client MUST write the
       file to non-volatile storage as FILENAME.EXT.
 
       * **4.5.2.5**. **Check against snapshot metadata.** The hashes (if any), and
-      version number of the new DELEGATE metadata file MUST match the trusted
+      version number of the new DELEGATEE metadata file MUST match the trusted
       snapshot metadata, if any.  This is done, in part, to prevent a mix-and-match
-      attack by man-in-the-middle attackers. If the new DELEGATE metadata file
+      attack by man-in-the-middle attackers. If the new DELEGATEE metadata file
       does not match, abort the update cycle, and report the failure.
 
-      * **4.5.2.6**. **Check for an arbitrary software attack.** The new DELEGATE
+      * **4.5.2.6**. **Check for an arbitrary software attack.** The new DELEGATEE
       metadata file MUST have been signed by a threshold of keys specified in the
-      TARGETS metadata file.  If the new DELEGATE metadata file is not signed
+      TARGETS metadata file.  If the new DELEGATEE metadata file is not signed
       as required, abort the update cycle, and report the failure.
 
-      * **4.5.2.7**. **Check for a rollback attack on the DELEGATE metadata.**
-      The version number of the trusted DELEGATE metadata file, if any, MUST be
-      less than or equal to the version number of the new DELEGATE metadata
-      file.  If the new DELEGATE metadata file is older than the trusted
-      DELEGATE metadata file abort the update cycle, and report the potential
+      * **4.5.2.7**. **Check for a rollback attack on the DELEGATEE metadata.**
+      The version number of the trusted DELEGATEE metadata file, if any, MUST be
+      less than or equal to the version number of the new DELEGATEE metadata
+      file.  If the new DELEGATEE metadata file is older than the trusted
+      DELEGATEE metadata file abort the update cycle, and report the potential
       rollback attack.
 
       * **4.5.2.8**. **Check for a freeze attack.** The latest known time
-      should be lower than the expiration timestamp in the new DELEGATE
-      metadata file. If so, the new DELEGATE file becomes the trusted DELEGATE
-      file. If the new DELEGATE metadata file is expired, abort the update
+      should be lower than the expiration timestamp in the new DELEGATEE
+      metadata file. If so, the new DELEGATEE file becomes the trusted DELEGATEE
+      file. If the new DELEGATEE metadata file is expired, abort the update
       cycle, and report the potential freeze attack.
 
       * **4.5.2.9**. If the current delegation is a multi-role delegation,
@@ -1348,7 +1348,7 @@ non-volatile storage as FILENAME.EXT.
 
       * **4.5.2.11**. Otherwise, if the current delegation is a non-terminating
       delegation, continue processing the next delegation, if any, by repeating
-      step 4.5 with DELEGATE as the current TARGET role. Stop the search, and
+      step 4.5 with DELEGATEE as the current TARGET role. Stop the search, and
       jump to step 5 as soon as a delegation returns a result.
 
 **5**. **Verify the desired target against its targets metadata**.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1313,11 +1313,12 @@ non-volatile storage as FILENAME.EXT.
       in the snapshot metadata file.  In either case, the client MUST write the
       file to non-volatile storage as FILENAME.EXT.
 
-      * **4.5.2.5**. **Check against snapshot metadata.** The hashes (if any), and
-      version number of the new DELEGATEE metadata file MUST match the trusted
-      snapshot metadata, if any.  This is done, in part, to prevent a mix-and-match
-      attack by man-in-the-middle attackers. If the new DELEGATEE metadata file
-      does not match, abort the update cycle, and report the failure.
+      * **4.5.2.5**. **Check against snapshot metadata.**  The hashes and
+      version number of the new DELEGATEE metadata file MUST match the hashes
+      (if any) and version number listed in the trusted snapshot metadata. This
+      is done, in part, to prevent a mix-and-match attack by man-in-the-middle
+      attackers. If the new DELEGATEE metadata file does not match, abort the
+      update cycle, and report the failure.
 
       * **4.5.2.6**. **Check for an arbitrary software attack.** The new DELEGATEE
       metadata file MUST have been signed by a threshold of keys specified in the

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1133,15 +1133,27 @@ repo](https://github.com/theupdateframework/specification/issues).
   cycle, report the potential freeze attack.  On the next update cycle, begin
   at step 0 and version N of the root metadata file.
 
-  * **1.9**. **If the timestamp and / or snapshot keys have been rotated, then
-  delete the trusted timestamp and snapshot metadata files.** This is done in
-  order to recover from fast-forward attacks after the repository has been
-  compromised and recovered. A _fast-forward attack_ happens when attackers
-  arbitrarily increase the version numbers of: (1) the timestamp metadata, (2)
-  the snapshot metadata, and / or (3) the targets, or a delegated targets,
-  metadata file in the snapshot metadata. Please see [the Mercury
+  * **1.9**. **Fast-forward attack recovery** A _fast-forward attack_ happens
+  when attackers arbitrarily increase the version numbers in any of the
+  timestamp, snapshot, targets, or delegated targets metadata. To recover from
+  fast-forward attacks after the repository has been compromised and recovered,
+  certain metadata files need to be deleted as specified in this section.
+  Please see [the Mercury
   paper](https://ssl.engineering.nyu.edu/papers/kuppusamy-mercury-usenix-2017.pdf)
   for more details.
+
+    * **1.9.1**. **Targets recovery** If a threshold of targets keys are removed
+    from the root metadata, delete the old top-level targets, snapshot, and
+    timestamp metadata files.
+
+    * **1.9.2**. **Snapshot recovery** If a threshold of snapshot keys have
+    been removed in the new trusted root metadata compared to the previous
+    trusted root metadata, delete the old snapshot and timestamp metadata
+    files.
+
+    * **1.9.3**. **Timestamp recovery** If a threshold of timestamp keys have
+    been removed from the new trusted root metadata compared to the previous
+    trusted root metadata, delete the old timestamp metadata file.
 
   * **1.10**. **Set whether consistent snapshots are used as per the trusted
   root metadata file** (see Section 4.3).


### PR DESCRIPTION
This PR combines and updates #72, which clarifies the verification routines for delegated targets, and #74 and #85, which fix #71, i.e. resolve ambiguity around rotating keys and deleting metadata, in order to recover from fast-forward attacks, by temporarily disabling rollback attack checks.

**Pre-requisite**
- 0ecf980 reverts #65 (see commit message for rationale)

**Takeover of #72**
- 75ac163 is a verbatim copy of the sole commit from #72 courtesy of @erickt
- 329361a,  c36e0c0  and e4a6f9e address #72-reviews (by [*@lukpueh*](https://github.com/theupdateframework/specification/pull/72#pullrequestreview-331245904) and [*@mnm678*](https://github.com/theupdateframework/specification/pull/72#issuecomment-565595339))

**Takeover of #85**
- Please see commit messages of b677f6a, fa2d263 and most notably 65e042d for details
