### PR TITLE
Remove TAP 3 + 4 adherence claim

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,6 +1,6 @@
 # <p align="center">The Update Framework Specification
 
-Last modified: **13 September 2019**
+Last modified: **5 March 2020**
 
 Version: **1.0.0**
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -214,10 +214,6 @@ repo](https://github.com/theupdateframework/specification/issues).
 
       * This version (1.0.0) of the specification adheres to the following TAPS:
 
-        - [TAP 3](https://github.com/theupdateframework/taps/blob/master/tap3.md): 
-            Multi Role Delegations
-        - [TAP 4](https://github.com/theupdateframework/taps/blob/master/tap4.md):
-            Multiple Repository Consensus on entrusted targets
         - [TAP 6](https://github.com/theupdateframework/taps/blob/master/tap6.md):
             Include specification version in metadata
         - [TAP 9](https://github.com/theupdateframework/taps/blob/master/tap9.md):


### PR DESCRIPTION
The specification claims that it adheres to TAP 3 and TAP 4, which is not the case. TAP 3 requires changes to the existing metadata format (prepared in #57) and TAP 4 adds a new metadata file (map.json), which is not yet mentioned in the specification (issue described in #88).

As agreed in the TUF community meeting on Dec 10, 2019, we remove TAP 3 and TAP 4 (adherence claims) for a formal 1.0.0 release and will add TAP 4 in version 1.1.x and TAP 3 in version 2.x.x.
(see [meeting notes about "Versioning" ](https://groups.google.com/forum/#!msg/theupdateframework/oPTliXibT_4/0tJ_POLGAwAJ))

*NOTE: Let's ignore the version management strategy and checker results for this PR. As agreed in the meeting (see notes above) this will be the last change before we formally release TUF 1.0.0. After that, we should stick to the rules defined in #87.*
