### PR TITLE
Only suggest a release in check_release.py fo merges from draft

### DIFF
--- a/check_release.py
+++ b/check_release.py
@@ -152,7 +152,8 @@ def main():
 
   print("*"*68)
   print("thanks for correctly bumping version and last modified date. :)")
-  print("don't forget to tag the release and to sync 'draft' with master!! :P")
+  if os.environ["TRAVIS_PULL_REQUEST_BRANCH"] == "draft":
+    print("don't forget to tag the release and to sync 'draft' with master!! :P")
   print("*"*68)
 
 


### PR DESCRIPTION
A minor tweak to `check_release.py` to only suggest that the submitter tag a release and synch the draft branch with master when merging changes from the draft branch.
