### PR TITLE
Update snapshot role definition

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -331,8 +331,8 @@ repo](https://github.com/theupdateframework/specification/issues).
   - **2.1.3 Snapshot role**
 
       The snapshot role signs a metadata file that provides information about
-      the latest version of all of the other metadata on the repository
-      (excluding the timestamp file, discussed below).  This information allows
+      the latest version of all targets metadata on the repository
+      (the top-level targets.json and all delegated roles).  This information allows
       clients to know which metadata files have been updated and also prevents
       mix-and-match attacks.
 
@@ -422,7 +422,8 @@ repo](https://github.com/theupdateframework/specification/issues).
     /snapshot.json
 
          Signed by the snapshot role's keys.  Lists the version numbers of all
-         metadata files other than timestamp.json.
+         target metadata files: the top-level targets.json and all delegated
+         roles.
 
     /targets.json
 
@@ -1384,7 +1385,7 @@ non-volatile storage as FILENAME.EXT.
     snapshots are not written by the repository, then the attribute may either
     be left unspecified or be set to the False value.  Otherwise, it must be
     set to the True value.
-    
+
     Regardless of whether consistent snapshots are ever used or not, all
     released versions of root metadata files should always be provided
     so that outdated clients can update to the latest available root.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,8 +1,8 @@
 # <p align="center">The Update Framework Specification
 
-Last modified: **6 March 2020**
+Last modified: **4 May 2020**
 
-Version: **1.0.1**
+Version: **1.0.2**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an


### PR DESCRIPTION
**Issue:** Inconsistency in snapshot role definition throughout the specification

Snapshot role definition in 2.1.3 and 3.1.2 states that:

> The snapshot role signs a metadata file that provides information about the latest version of all of the other metadata on the repository  (excluding the timestamp file, discussed below).

While the detailed file formats description in 4.4 says: 

>  It MUST list the version numbers of the top-level targets metadata and all delegated targets metadata. 

From the latter, we understand that both `root.json` and `timestamp.json` are excluded from the snapshot which is also shown in the example files.

**Proposed changes:** 
Update snapshot role definition in 2.1.3 and 3.1.2 to match the  file format description (4.4) and explicitly state which metadata files must be listed in snapshot.json 
