### PR TITLE
Remove slow retrieval attacks from protections

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,8 +1,8 @@
 # <p align="center">The Update Framework Specification
 
-Last modified: **23 September 2020**
+Last modified: **29 September 2020**
 
-Version: **1.0.6**
+Version: **1.0.7**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -183,10 +183,6 @@ repo](https://github.com/theupdateframework/specification/issues).
       software that is older than that which the client previously knew to be
       available.
 
-      + **Slow retrieval attacks.**  An attacker cannot prevent clients from
-      being aware of interference with receiving updates by responding to
-      client requests so slowly that automated updates never complete.
-
       + **Vulnerability to key compromises.** An attacker, who is able to
       compromise a single key or less than a given threshold of keys, cannot
       compromise clients.  This includes compromising a single online key (such


### PR DESCRIPTION
I think we should remove slow retrieval attacks from 1.5.2. Goals to protect against specific attacks. I've included details in the commit message but the tl;dr is that:
1. AFAICT nothing in the _specification_ protects against these attacks
2. implementing protections against slow retrieval attacks has a high complexity for implementers which is not met by sufficient need
3. ownership of the network/download stack, in order to protect against slow retrieval attacks, is not something that clients are willing to give up (i.e. pip has thoroughly tested download code that they'd like to keep using)