### PR TITLE
Remove 2nd snapshot rollback attack check

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,8 +1,8 @@
 # <p align="center">The Update Framework Specification
 
-Last modified: **26 August 2020**
+Last modified: **23 September 2020**
 
-Version: **1.0.5**
+Version: **1.0.6**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an
@@ -1199,22 +1199,14 @@ non-volatile storage as FILENAME.EXT.
   file.  If the new snapshot metadata file is not signed as required, discard
   it, abort the update cycle, and report the signature failure.
 
-  * **3.3**. **Check for a rollback attack.**
-
-    * **3.3.1**. The version number of the trusted snapshot metadata file, if
-    any, MUST be less than or equal to the version number of the new snapshot
-    metadata file.  If the new snapshot metadata file is older than the trusted
-    metadata file, discard it, abort the update cycle, and report the potential
-    rollback attack.
-
-    * **3.3.2**. The version number of the targets metadata file, and all
-    delegated targets metadata files (if any), in the trusted snapshot metadata
-    file, if any, MUST be less than or equal to its version number in the new
-    snapshot metadata file. Furthermore, any targets metadata filename that was
-    listed in the trusted snapshot metadata file, if any, MUST continue to be
-    listed in the new snapshot metadata file.  If any of these conditions are
-    not met, discard the new snapshot metadadata file, abort the update cycle,
-    and report the failure.
+  * **3.3**. **Check for a rollback attack.** The version number of the targets
+  metadata file, and all delegated targets metadata files (if any), in the
+  trusted snapshot metadata file, if any, MUST be less than or equal to its
+  version number in the new snapshot metadata file. Furthermore, any targets
+  metadata filename that was listed in the trusted snapshot metadata file, if
+  any, MUST continue to be listed in the new snapshot metadata file.  If any of
+  these conditions are not met, discard the new snapshot metadadata file, abort
+  the update cycle, and report the failure.
 
   * **3.4**. **Check for a freeze attack.** The latest known time should be
   lower than the expiration timestamp in the new snapshot metadata file.  If


### PR DESCRIPTION
This shares the same justification for removal as #65. Step 3.3.1 was made redundant by #106, which modified the workflow to add 2.2.2, where updating the timestamp will also check if the new timestamp contains a snapshot version that is less than the trusted snapshot version.

This, in combination with the 3.1 check that asserts hashes and version of the actual snapshot metadata match the ones in the new trusted timestamp, make another version check, i.e, the one removed in this commit, obsolete.