### PR TITLE
Clean up language

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1096,17 +1096,17 @@ repo](https://github.com/theupdateframework/specification/issues).
   kilobytes. The filename used to download the root metadata file is of the
   fixed form VERSION_NUMBER.FILENAME.EXT (e.g., 42.root.json). If this file is
   not available, or we have downloaded more than Y number of root metadata
-  files (because the exact number is as yet unknown), then go to step 1.8. The
-  value for Y is set by the authors of the application using TUF. For example,
-  Y may be 2^10.
+  files (because the exact number is as yet unknown), then go to step 5.1.9.
+  The value for Y is set by the authors of the application using TUF. For
+  example, Y may be 2^10.
 
   * **5.1.3. Check for an arbitrary software attack.** Version N+1 of the root
   metadata file MUST have been signed by: (1) a threshold of keys specified in
   the trusted root metadata file (version N), and (2) a threshold of keys
   specified in the new root metadata file being validated (version N+1).  If
   version N+1 is not signed as required, discard it, abort the update cycle,
-  and report the signature failure.  On the next update cycle, begin at step 0
-  and version N of the root metadata file.
+  and report the signature failure.  On the next update cycle, begin at step
+  5.0 and version N of the root metadata file.
 
   * **5.1.4. Check for a rollback attack.** The version number of the trusted
   root metadata file (version N) MUST be less than or equal to the version
@@ -1114,11 +1114,11 @@ repo](https://github.com/theupdateframework/specification/issues).
   checking that the version number signed in the new root metadata file is
   indeed N+1.  If the version of the new root metadata file is less than the
   trusted metadata file, discard it, abort the update cycle, and report the
-  rollback attack.  On the next update cycle, begin at step 0 and version N of
-  the root metadata file.
+  rollback attack.  On the next update cycle, begin at step 5.0 and version N
+  of the root metadata file.
 
   * **5.1.5**. Note that the expiration of the new (intermediate) root metadata
-  file does not matter yet, because we will check for it in step 5.1.8.
+  file does not matter yet, because we will check for it in step 5.1.9.
 
   * **5.1.6**. **Set the trusted root metadata file** to the new root metadata
   file.
@@ -1132,7 +1132,7 @@ repo](https://github.com/theupdateframework/specification/issues).
   lower than the expiration timestamp in the trusted root metadata file
   (version N).  If the trusted root metadata file has expired, abort the update
   cycle, report the potential freeze attack.  On the next update cycle, begin
-  at step 0 and version N of the root metadata file.
+  at step 5.0 and version N of the root metadata file.
 
   * **5.1.10**. **If the timestamp and / or snapshot keys have been rotated,
   then delete the trusted timestamp and snapshot metadata files.** This is done
@@ -1254,15 +1254,15 @@ snapshot metadata file.
 
   * **5.4.5**. **Perform a pre-order depth-first search for metadata about the
   desired target, beginning with the top-level targets role.**  Note: If
-  any metadata requested in steps 5.4.4.1 - 5.4.4.2.3 cannot be downloaded nor
+  any metadata requested in steps 5.4.5.1 - 5.4.5.2 cannot be downloaded nor
   validated, end the search and report that the target cannot be found.
 
     * **5.4.5.1**. If this role has been visited before, then skip this role
     (so that cycles in the delegation graph are avoided).  Otherwise, if an
     application-specific maximum number of roles have been visited, then go to
-    step 5 (so that attackers cannot cause the client to waste excessive
+    step 5.5 (so that attackers cannot cause the client to waste excessive
     bandwidth or time).  Otherwise, if this role contains metadata about the
-    desired target, then go to step 5.
+    desired target, then go to step 5.5.
 
     * **5.4.5.2**. Otherwise, recursively search the list of delegations in
     order of appearance.
@@ -1273,12 +1273,12 @@ snapshot metadata file.
       the lack of any such metadata).
 
       * **5.4.5.2.2**. If the current delegation is a terminating delegation,
-      then jump to step 5.
+      then jump to step 5.5.
 
       * **5.4.5.2.3**. Otherwise, if the current delegation is a
       non-terminating delegation, continue processing the next delegation, if
-      any. Stop the search, and jump to step 5 as soon as a delegation returns
-      a result.
+      any. Stop the search, and jump to step 5.5 as soon as a delegation
+      returns a result.
 
 **5.5**. **Verify the desired target against its targets metadata**.
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1073,33 +1073,34 @@ repo](https://github.com/theupdateframework/specification/issues).
   still be able to update again in the future. Errors raised during the update
   process should not leave clients in an unrecoverable state.
 
-  **0**. **Load the trusted root metadata file.** We assume that a good, trusted
-  copy of this file was shipped with the package manager or software updater
-  using an out-of-band process.  Note that the expiration of the trusted root
-  metadata file does not matter, because we will attempt to update it in the
-  next step.
+  **5.0**. **Load the trusted root metadata file.** We assume that a good,
+  trusted copy of this file was shipped with the package manager or software
+  updater using an out-of-band process.  Note that the expiration of the
+  trusted root metadata file does not matter, because we will attempt to update
+  it in the next step.
 
-  **1**. **Update the root metadata file.**
-  Since it may now be signed using entirely different keys, the client MUST
-  somehow be able to establish a trusted line of continuity to the latest set
-  of keys (see Section 6.1). To do so, the client MUST download intermediate
-  root metadata files, until the latest available one is reached. Therefore, it
-  MUST temporarily turn on consistent snapshots in order to download
-  _versioned_ root metadata files as described next.
+  **5.1**. **Update the root metadata file.** Since it may now be signed using
+  entirely different keys, the client MUST somehow be able to establish a
+  trusted line of continuity to the latest set of keys (see Section 6.1). To do
+  so, the client MUST download intermediate root metadata files, until the
+  latest available one is reached. Therefore, it MUST temporarily turn on
+  consistent snapshots in order to download _versioned_ root metadata files as
+  described next.
 
-  * **1.1**. Let N denote the version number of the trusted root metadata file.
+  * **5.1.1**. Let N denote the version number of the trusted root metadata
+  file.
 
-  * **1.2**. **Try downloading version N+1 of the root metadata file**, up to
+  * **5.1.2**. **Try downloading version N+1 of the root metadata file**, up to
   some W number of bytes (because the size is unknown). The value for W is set
   by the authors of the application using TUF. For example, W may be tens of
   kilobytes. The filename used to download the root metadata file is of the
   fixed form VERSION_NUMBER.FILENAME.EXT (e.g., 42.root.json). If this file is
-  not available, or we have downloaded more than Y number of root metadata files
-  (because the exact number is as yet unknown), then go to step 1.8. The value
-  for Y is set by the authors of the application using TUF. For example, Y may
-  be 2^10.
+  not available, or we have downloaded more than Y number of root metadata
+  files (because the exact number is as yet unknown), then go to step 1.8. The
+  value for Y is set by the authors of the application using TUF. For example,
+  Y may be 2^10.
 
-  * **1.3. Check for an arbitrary software attack.** Version N+1 of the root
+  * **5.1.3. Check for an arbitrary software attack.** Version N+1 of the root
   metadata file MUST have been signed by: (1) a threshold of keys specified in
   the trusted root metadata file (version N), and (2) a threshold of keys
   specified in the new root metadata file being validated (version N+1).  If
@@ -1107,7 +1108,7 @@ repo](https://github.com/theupdateframework/specification/issues).
   and report the signature failure.  On the next update cycle, begin at step 0
   and version N of the root metadata file.
 
-  * **1.4. Check for a rollback attack.** The version number of the trusted
+  * **5.1.4. Check for a rollback attack.** The version number of the trusted
   root metadata file (version N) MUST be less than or equal to the version
   number of the new root metadata file (version N+1). Effectively, this means
   checking that the version number signed in the new root metadata file is
@@ -1116,26 +1117,26 @@ repo](https://github.com/theupdateframework/specification/issues).
   rollback attack.  On the next update cycle, begin at step 0 and version N of
   the root metadata file.
 
-  * **1.5**. Note that the expiration of the new (intermediate) root metadata
-  file does not matter yet, because we will check for it in step 1.8.
+  * **5.1.5**. Note that the expiration of the new (intermediate) root metadata
+  file does not matter yet, because we will check for it in step 5.1.8.
 
-  * **1.6**. **Set the trusted root metadata file** to the new root metadata
+  * **5.1.6**. **Set the trusted root metadata file** to the new root metadata
   file.
 
-  * **1.7**. **Persist root metadata.** The client MUST write the file to
+  * **5.1.7**. **Persist root metadata.** The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. root.json).
 
-  * **1.8**. **Repeat steps 1.1 to 1.8**.
+  * **5.1.8**. **Repeat steps 5.1.1 to 5.1.8**.
 
-  * **1.9**. **Check for a freeze attack.** The latest known time MUST be
+  * **5.1.9**. **Check for a freeze attack.** The latest known time MUST be
   lower than the expiration timestamp in the trusted root metadata file
   (version N).  If the trusted root metadata file has expired, abort the update
   cycle, report the potential freeze attack.  On the next update cycle, begin
   at step 0 and version N of the root metadata file.
 
-  * **1.10**. **If the timestamp and / or snapshot keys have been rotated, then
-  delete the trusted timestamp and snapshot metadata files.** This is done in
-  order to recover from fast-forward attacks after the repository has been
+  * **5.1.10**. **If the timestamp and / or snapshot keys have been rotated,
+  then delete the trusted timestamp and snapshot metadata files.** This is done
+  in order to recover from fast-forward attacks after the repository has been
   compromised and recovered. A _fast-forward attack_ happens when attackers
   arbitrarily increase the version numbers of: (1) the timestamp metadata, (2)
   the snapshot metadata, and / or (3) the targets, or a delegated targets,
@@ -1143,44 +1144,44 @@ repo](https://github.com/theupdateframework/specification/issues).
   paper](https://ssl.engineering.nyu.edu/papers/kuppusamy-mercury-usenix-2017.pdf)
   for more details.
 
-  * **1.11**. **Set whether consistent snapshots are used as per the trusted
+  * **5.1.11**. **Set whether consistent snapshots are used as per the trusted
   root metadata file** (see Section 4.3).
 
-**2**. **Download the timestamp metadata file**, up to X number of bytes
+**5.2**. **Download the timestamp metadata file**, up to X number of bytes
 (because the size is unknown). The value for X is set by the authors of the
 application using TUF. For example, X may be tens of kilobytes. The filename
 used to download the timestamp metadata file is of the fixed form FILENAME.EXT
 (e.g., timestamp.json).
 
-  * **2.1**. **Check for an arbitrary software attack.** The new timestamp
+  * **5.2.1**. **Check for an arbitrary software attack.** The new timestamp
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new timestamp metadata file is not
   properly signed, discard it, abort the update cycle, and report the signature
   failure.
 
-  * **2.2**. **Check for a rollback attack.**
+  * **5.2.2**. **Check for a rollback attack.**
 
-    * **2.2.1**. The version number of the trusted timestamp metadata file, if
+    * **5.2.2.1**. The version number of the trusted timestamp metadata file, if
     any, MUST be less than or equal to the version number of the new timestamp
     metadata file.  If the new timestamp metadata file is older than the
     trusted timestamp metadata file, discard it, abort the update cycle, and
     report the potential rollback attack.
 
-    * **2.2.2**. The version number of the snapshot metadata file in the
+    * **5.2.2.2**. The version number of the snapshot metadata file in the
     trusted timestamp metadata file, if any, MUST be less than or equal to its
     version number in the new timestamp metadata file.  If not, discard the new
     timestamp metadata file, abort the update cycle, and report the failure.
 
-  * **2.3**. **Check for a freeze attack.** The latest known time MUST be
+  * **5.2.3**. **Check for a freeze attack.** The latest known time MUST be
   lower than the expiration timestamp in the new timestamp metadata file.  If
   so, the new timestamp metadata file becomes the trusted timestamp metadata
   file.  If the new timestamp metadata file has expired, discard it, abort the
   update cycle, and report the potential freeze attack.
 
-  * **2.4**. **Persist timestamp metadata.** The client MUST write the file to
-  non-volatile storage as FILENAME.EXT (e.g. timestamp.json).
+  * **5.2.4**. **Persist timestamp metadata.** The client MUST write the file
+  to non-volatile storage as FILENAME.EXT (e.g. timestamp.json).
 
-**3**. **Download snapshot metadata file**, up to either the number of bytes
+**5.3**. **Download snapshot metadata file**, up to either the number of bytes
 specified in the timestamp metadata file, or some Y number of bytes. The value
 for Y is set by the authors of the application using TUF. For example, Y may be
 tens of kilobytes. If consistent snapshots are not used (see
@@ -1190,19 +1191,19 @@ of the form VERSION_NUMBER.FILENAME.EXT (e.g., 42.snapshot.json), where
 VERSION_NUMBER is the version number of the snapshot metadata file listed in
 the timestamp metadata file.
 
-  * **3.1**. **Check against timestamp metadata.** The hashes and version
+  * **5.3.1**. **Check against timestamp metadata.** The hashes and version
   number of the new snapshot metadata file MUST match the hashes, if any, and
   version number listed in the trusted timestamp metadata.  If hashes and
   version do not match, discard the new snapshot metadata, abort the update
   cycle, and report the failure.
 
-  * **3.2**. **Check for an arbitrary software attack.** The new snapshot
+  * **5.3.2**. **Check for an arbitrary software attack.** The new snapshot
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new snapshot metadata file is not signed
   as required, discard it, abort the update cycle, and report the signature
   failure.
 
-  * **3.3**. **Check for a rollback attack.** The version number of the targets
+  * **5.3.3**. **Check for a rollback attack.** The version number of the targets
   metadata file, and all delegated targets metadata files, if any, in the
   trusted snapshot metadata file, if any, MUST be less than or equal to its
   version number in the new snapshot metadata file. Furthermore, any targets
@@ -1211,16 +1212,16 @@ the timestamp metadata file.
   these conditions are not met, discard the new snapshot metadata file, abort
   the update cycle, and report the failure.
 
-  * **3.4**. **Check for a freeze attack.** The latest known time MUST be
+  * **5.3.4**. **Check for a freeze attack.** The latest known time MUST be
   lower than the expiration timestamp in the new snapshot metadata file.  If
   so, the new snapshot metadata file becomes the trusted snapshot metadata
   file. If the new snapshot metadata file is expired, discard it, abort the
   update cycle, and report the potential freeze attack.
 
-  * **3.5**. **Persist snapshot metadata.** The client MUST write the file to
+  * **5.3.5**. **Persist snapshot metadata.** The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. snapshot.json).
 
-**4**. **Download the top-level targets metadata file**, up to either the
+**5.4**. **Download the top-level targets metadata file**, up to either the
 number of bytes specified in the snapshot metadata file, or some Z number of
 bytes. The value for Z is set by the authors of the application using TUF. For
 example, Z may be tens of kilobytes.  If consistent snapshots are not used (see
@@ -1230,60 +1231,61 @@ of the form VERSION_NUMBER.FILENAME.EXT (e.g., 42.targets.json), where
 VERSION_NUMBER is the version number of the targets metadata file listed in the
 snapshot metadata file.
 
-  * **4.1**. **Check against snapshot metadata.** The hashes and version
+  * **5.4.1**. **Check against snapshot metadata.** The hashes and version
   number of the new targets metadata file MUST match the hashes, if any, and
   version number listed in the trusted snapshot metadata.  This is done, in
   part, to prevent a mix-and-match attack by man-in-the-middle attackers.  If
   the new targets metadata file does not match, discard it, abort the update
   cycle, and report the failure.
 
-  * **4.2**. **Check for an arbitrary software attack.** The new targets
+  * **5.4.2**. **Check for an arbitrary software attack.** The new targets
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new targets metadata file is not signed
   as required, discard it, abort the update cycle, and report the failure.
 
-  * **4.3**. **Check for a freeze attack.** The latest known time MUST be
+  * **5.4.3**. **Check for a freeze attack.** The latest known time MUST be
   lower than the expiration timestamp in the new targets metadata file.  If so,
   the new targets metadata file becomes the trusted targets metadata file.  If
   the new targets metadata file is expired, discard it, abort the update cycle,
   and report the potential freeze attack.
 
-  * **4.4**. **Persist targets metadata.** The client MUST write the file to
+  * **5.4.4**. **Persist targets metadata.** The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. targets.json).
 
-  * **4.5**. **Perform a pre-order depth-first search for metadata about the
+  * **5.4.5**. **Perform a pre-order depth-first search for metadata about the
   desired target, beginning with the top-level targets role.**  Note: If
-  any metadata requested in steps 4.4.1 - 4.4.2.3 cannot be downloaded nor
+  any metadata requested in steps 5.4.4.1 - 5.4.4.2.3 cannot be downloaded nor
   validated, end the search and report that the target cannot be found.
 
-    * **4.5.1**. If this role has been visited before, then skip this role (so
-    that cycles in the delegation graph are avoided).  Otherwise, if an
+    * **5.4.5.1**. If this role has been visited before, then skip this role
+    (so that cycles in the delegation graph are avoided).  Otherwise, if an
     application-specific maximum number of roles have been visited, then go to
     step 5 (so that attackers cannot cause the client to waste excessive
     bandwidth or time).  Otherwise, if this role contains metadata about the
     desired target, then go to step 5.
 
-    * **4.5.2**. Otherwise, recursively search the list of delegations in order
-    of appearance.
+    * **5.4.5.2**. Otherwise, recursively search the list of delegations in
+    order of appearance.
 
-      * **4.5.2.1**. If the current delegation is a multi-role delegation,
+      * **5.4.5.2.1**. If the current delegation is a multi-role delegation,
       recursively visit each role, and check that each has signed exactly the
       same non-custom metadata (i.e., length and hashes) about the target (or
       the lack of any such metadata).
 
-      * **4.5.2.2**. If the current delegation is a terminating delegation,
+      * **5.4.5.2.2**. If the current delegation is a terminating delegation,
       then jump to step 5.
 
-      * **4.5.2.3**. Otherwise, if the current delegation is a non-terminating
-      delegation, continue processing the next delegation, if any. Stop the
-      search, and jump to step 5 as soon as a delegation returns a result.
+      * **5.4.5.2.3**. Otherwise, if the current delegation is a
+      non-terminating delegation, continue processing the next delegation, if
+      any. Stop the search, and jump to step 5 as soon as a delegation returns
+      a result.
 
-**5**. **Verify the desired target against its targets metadata**.
+**5.5**. **Verify the desired target against its targets metadata**.
 
-  * **5.1**. If there is no targets metadata about this target, abort the
+  * **5.5.1**. If there is no targets metadata about this target, abort the
   update cycle and report that there is no such target.
 
-  * **5.2**. Otherwise, download the target (up to the number of bytes
+  * **5.5.2**. Otherwise, download the target (up to the number of bytes
   specified in the targets metadata), and verify that its hashes match the
   targets metadata. (We download up to this number of bytes, because in some
   cases, the exact number is unknown. This may happen, for example, if an
@@ -1332,8 +1334,7 @@ snapshot metadata file.
    repository. This ensures that an outdated client can always correctly
    re-trace the chain of trust across multiple root key updates, even if the
    latest set of root keys on the client dates back multiple root metadata
-   versions. See step 1 of the client application workflow in Section 5 for
-   more details.
+   versions. See step 5.1 of the client application workflow for more details.
 
    Note that an attacker, who controls the repository, can launch freeze
    attacks by withholding new root metadata. The attacker does not need to

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -2,7 +2,7 @@
 
 Last modified: **29 September 2020**
 
-Version: **1.0.8**
+Version: **1.0.9**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an
@@ -29,7 +29,7 @@ repo](https://github.com/theupdateframework/specification/issues).
 
    The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD,"
    "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be
-   interpreted as described in RFC 2119.
+   interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 * **1.2. Motivation**
 
@@ -52,9 +52,10 @@ repo](https://github.com/theupdateframework/specification/issues).
 * **1.3. History and credit**
 
    Work on TUF began in late 2009.  The core ideas are based off of previous
-   work done by Justin Cappos and Justin Samuel that identified security flaws
-   in all popular Linux package managers.  More information and current
-   versions of this document can be found at https://www.updateframework.com/
+   work done by Justin Cappos and Justin Samuel that [identified security flaws
+   in all popular Linux package managers](https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf).
+   More information and current versions of this document can be found at
+   https://theupdateframework.io/
 
    The [Global Environment for Network Innovations](https://www.geni.net/) (GENI)
    and the [National Science Foundation](https://www.nsf.gov/) (NSF) have
@@ -286,10 +287,10 @@ repo](https://github.com/theupdateframework/specification/issues).
       + The root role delegates trust to specific keys trusted for all other
    top-level roles used in the system.
 
-      + The client-side of the framework must ship with trusted root keys for each
+      + The client-side of the framework MUST ship with trusted root keys for each
    configured repository.
 
-      + The root role's private keys must be kept very secure and thus should be
+      + The root role's private keys MUST be kept very secure and thus should be
    kept offline.  If less than a threshold of Root keys are compromised, the
    repository should revoke trust on the compromised keys.  This can be
    accomplished with a normal rotation of root keys, covered in section 6.1
@@ -338,7 +339,7 @@ repo](https://github.com/theupdateframework/specification/issues).
       whose signature has not yet expired, an automated process periodically signs
       a timestamped statement containing the hash of the snapshot file.  Even
       though this timestamp key must be kept online, the risk posed to clients by
-      compromise of this key is minimal.
+      the compromise of this key is minimal.
 
   - **2.1.5 Mirrors role**
 
@@ -545,7 +546,7 @@ repo](https://github.com/theupdateframework/specification/issues).
           "keyval" : {"public" : PUBLIC}
         }
 
-   where PUBLIC is in PEM format and a string.  All RSA keys must be at least
+   where PUBLIC is in PEM format and a string.  All RSA keys MUST be at least
    2048 bits.
 
    The 'ed25519' format is:
@@ -624,11 +625,11 @@ repo](https://github.com/theupdateframework/specification/issues).
 
    A ROLE is one of "root", "snapshot", "targets", "timestamp", or "mirrors".
    A role for each of "root", "snapshot", "timestamp", and "targets" MUST be
-   specified in the key list. The role of "mirror" is optional.  If not
+   specified in the key list. The role of "mirror" is OPTIONAL.  If not
    specified, the mirror list will not need to be signed if mirror lists are
    being used.
 
-   The KEYID must be correct for the specified KEY.  Clients MUST calculate
+   The KEYID MUST be correct for the specified KEY.  Clients MUST calculate
    each KEYID to verify this is correct for the associated key.  Clients MUST
    ensure that for any KEYID represented in this key list and in other files,
    only one unique key has that KEYID.
@@ -974,7 +975,7 @@ repo](https://github.com/theupdateframework/specification/issues).
 * **4.6. File formats: timestamp.json**
 
    The timestamp file is signed by a timestamp key.  It indicates the latest
-   version of the snapshot metadata and is frequently resigned to limit the
+   version of the snapshot metadata and is frequently re-signed to limit the
    amount of time a client can be kept unaware of interference with obtaining
    updates.
 
@@ -1079,7 +1080,7 @@ repo](https://github.com/theupdateframework/specification/issues).
   next step.
 
   **1**. **Update the root metadata file.**
-  Since it may now be signed using entirely different keys, the client must
+  Since it may now be signed using entirely different keys, the client MUST
   somehow be able to establish a trusted line of continuity to the latest set
   of keys (see Section 6.1). To do so, the client MUST download intermediate
   root metadata files, until the latest available one is reached. Therefore, it
@@ -1098,16 +1099,16 @@ repo](https://github.com/theupdateframework/specification/issues).
   for Y is set by the authors of the application using TUF. For example, Y may
   be 2^10.
 
-  * **1.3. Check signatures.** Version N+1 of the root metadata file MUST have
-  been signed by: (1) a threshold of keys specified in the trusted root
-  metadata file (version N), and (2) a threshold of keys specified in the new
-  root metadata file being validated (version N+1).  If version N+1 is not
-  signed as required, discard it, abort the update cycle, and report the
-  signature failure.  On the next update cycle, begin at step 0 and version N
-  of the root metadata file.
+  * **1.3. Check for an arbitrary software attack.** Version N+1 of the root
+  metadata file MUST have been signed by: (1) a threshold of keys specified in
+  the trusted root metadata file (version N), and (2) a threshold of keys
+  specified in the new root metadata file being validated (version N+1).  If
+  version N+1 is not signed as required, discard it, abort the update cycle,
+  and report the signature failure.  On the next update cycle, begin at step 0
+  and version N of the root metadata file.
 
   * **1.4. Check for a rollback attack.** The version number of the trusted
-  root metadata file (version N) must be less than or equal to the version
+  root metadata file (version N) MUST be less than or equal to the version
   number of the new root metadata file (version N+1). Effectively, this means
   checking that the version number signed in the new root metadata file is
   indeed N+1.  If the version of the new root metadata file is less than the
@@ -1126,7 +1127,7 @@ repo](https://github.com/theupdateframework/specification/issues).
 
   * **1.8**. **Repeat steps 1.1 to 1.8**.
 
-  * **1.9**. **Check for a freeze attack.** The latest known time should be
+  * **1.9**. **Check for a freeze attack.** The latest known time MUST be
   lower than the expiration timestamp in the trusted root metadata file
   (version N).  If the trusted root metadata file has expired, abort the update
   cycle, report the potential freeze attack.  On the next update cycle, begin
@@ -1151,15 +1152,16 @@ application using TUF. For example, X may be tens of kilobytes. The filename
 used to download the timestamp metadata file is of the fixed form FILENAME.EXT
 (e.g., timestamp.json).
 
-  * **2.1**. **Check signatures.** The new timestamp metadata file must have
-  been signed by a threshold of keys specified in the trusted root metadata
-  file.  If the new timestamp metadata file is not properly signed, discard it,
-  abort the update cycle, and report the signature failure.
+  * **2.1**. **Check for an arbitrary software attack.** The new timestamp
+  metadata file MUST have been signed by a threshold of keys specified in the
+  trusted root metadata file.  If the new timestamp metadata file is not
+  properly signed, discard it, abort the update cycle, and report the signature
+  failure.
 
   * **2.2**. **Check for a rollback attack.**
 
     * **2.2.1**. The version number of the trusted timestamp metadata file, if
-    any, must be less than or equal to the version number of the new timestamp
+    any, MUST be less than or equal to the version number of the new timestamp
     metadata file.  If the new timestamp metadata file is older than the
     trusted timestamp metadata file, discard it, abort the update cycle, and
     report the potential rollback attack.
@@ -1167,9 +1169,9 @@ used to download the timestamp metadata file is of the fixed form FILENAME.EXT
     * **2.2.2**. The version number of the snapshot metadata file in the
     trusted timestamp metadata file, if any, MUST be less than or equal to its
     version number in the new timestamp metadata file.  If not, discard the new
-    timestamp metadadata file, abort the update cycle, and report the failure.
+    timestamp metadata file, abort the update cycle, and report the failure.
 
-  * **2.3**. **Check for a freeze attack.** The latest known time should be
+  * **2.3**. **Check for a freeze attack.** The latest known time MUST be
   lower than the expiration timestamp in the new timestamp metadata file.  If
   so, the new timestamp metadata file becomes the trusted timestamp metadata
   file.  If the new timestamp metadata file has expired, discard it, abort the
@@ -1189,26 +1191,27 @@ VERSION_NUMBER is the version number of the snapshot metadata file listed in
 the timestamp metadata file.
 
   * **3.1**. **Check against timestamp metadata.** The hashes and version
-  number of the new snapshot metadata file MUST match the hashes (if any) and
+  number of the new snapshot metadata file MUST match the hashes, if any, and
   version number listed in the trusted timestamp metadata.  If hashes and
   version do not match, discard the new snapshot metadata, abort the update
   cycle, and report the failure.
 
-  * **3.2**. **Check signatures.** The new snapshot metadata file MUST have
-  been signed by a threshold of keys specified in the trusted root metadata
-  file.  If the new snapshot metadata file is not signed as required, discard
-  it, abort the update cycle, and report the signature failure.
+  * **3.2**. **Check for an arbitrary software attack.** The new snapshot
+  metadata file MUST have been signed by a threshold of keys specified in the
+  trusted root metadata file.  If the new snapshot metadata file is not signed
+  as required, discard it, abort the update cycle, and report the signature
+  failure.
 
   * **3.3**. **Check for a rollback attack.** The version number of the targets
-  metadata file, and all delegated targets metadata files (if any), in the
+  metadata file, and all delegated targets metadata files, if any, in the
   trusted snapshot metadata file, if any, MUST be less than or equal to its
   version number in the new snapshot metadata file. Furthermore, any targets
   metadata filename that was listed in the trusted snapshot metadata file, if
   any, MUST continue to be listed in the new snapshot metadata file.  If any of
-  these conditions are not met, discard the new snapshot metadadata file, abort
+  these conditions are not met, discard the new snapshot metadata file, abort
   the update cycle, and report the failure.
 
-  * **3.4**. **Check for a freeze attack.** The latest known time should be
+  * **3.4**. **Check for a freeze attack.** The latest known time MUST be
   lower than the expiration timestamp in the new snapshot metadata file.  If
   so, the new snapshot metadata file becomes the trusted snapshot metadata
   file. If the new snapshot metadata file is expired, discard it, abort the
@@ -1228,7 +1231,7 @@ VERSION_NUMBER is the version number of the targets metadata file listed in the
 snapshot metadata file.
 
   * **4.1**. **Check against snapshot metadata.** The hashes and version
-  number of the new targets metadata file MUST match the hashes (if any) and
+  number of the new targets metadata file MUST match the hashes, if any, and
   version number listed in the trusted snapshot metadata.  This is done, in
   part, to prevent a mix-and-match attack by man-in-the-middle attackers.  If
   the new targets metadata file does not match, discard it, abort the update
@@ -1239,7 +1242,7 @@ snapshot metadata file.
   trusted root metadata file.  If the new targets metadata file is not signed
   as required, discard it, abort the update cycle, and report the failure.
 
-  * **4.3**. **Check for a freeze attack.** The latest known time should be
+  * **4.3**. **Check for a freeze attack.** The latest known time MUST be
   lower than the expiration timestamp in the new targets metadata file.  If so,
   the new targets metadata file becomes the trusted targets metadata file.  If
   the new targets metadata file is expired, discard it, abort the update cycle,
@@ -1248,7 +1251,7 @@ snapshot metadata file.
   * **4.4**. **Persist targets metadata.** The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. targets.json).
 
-  * **4.5**. **Perform a preorder depth-first search for metadata about the
+  * **4.5**. **Perform a pre-order depth-first search for metadata about the
   desired target, beginning with the top-level targets role.**  Note: If
   any metadata requested in steps 4.4.1 - 4.4.2.3 cannot be downloaded nor
   validated, end the search and report that the target cannot be found.
@@ -1297,7 +1300,7 @@ snapshot metadata file.
 
 ## **6. Usage**
 
-   See https://www.theupdateframework.com/ for discussion of recommended usage
+   See https://theupdateframework.io/ for discussion of recommended usage
    in various situations.
 
 * **6.1. Key management and migration**
@@ -1377,7 +1380,7 @@ snapshot metadata file.
     the cryptographic function) from all digests in the referred file.
 
     Additionally, the timestamp metadata (timestamp.json) should also be
-    written to non-volatile storage whenever it is updated. It is optional for
+    written to non-volatile storage whenever it is updated. It is OPTIONAL for
     an implementation to write identical copies at
     version_number.timestamp.json for record-keeping purposes, because a
     cryptographic hash of the timestamp metadata is usually not known in

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,6 +1,6 @@
 # <p align="center">The Update Framework Specification
 
-Last modified: **29 September 2020**
+Last modified: **30 September 2020**
 
 Version: **1.0.9**
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -13,14 +13,14 @@ repo](https://github.com/theupdateframework/specification/issues).
 
 
 ## Table of Contents ##
-- [Introduction](#1-introduction)
-- [System Overview](#2-system-overview)
-- [The Repository](#3-the-repository)
-- [Document Formats](#4-document-formats)
-- [Detailed Workflows](#5-detailed-workflows)
-- [Usage](#6-usage)
-- [Consistent Snapshots](#7-consistent-snapshots)
-- [Future Directions and Open Questions](#f-future-directions-and-open-questions)
+- [1. Introduction](#1-introduction)
+- [2. System Overview](#2-system-overview)
+- [3. The Repository](#3-the-repository)
+- [4. Document Formats](#4-document-formats)
+- [5. Detailed Workflows](#5-detailed-workflows)
+- [6. Usage](#6-usage)
+- [7. Consistent Snapshots](#7-consistent-snapshots)
+- [F. Future Directions and Open Questions](#f-future-directions-and-open-questions)
 
 ## **1. Introduction**
 * **1.1. Scope**


### PR DESCRIPTION
* Switch many cases of must, optional to MUST, OPTIONAL to match RFC-2119.
* Change Freeze-Attack to use MUST instead of "should".
* Update links to https://theupdateframework.io
* Fix some typos.
* Standardize convention from "(if any)" to ", if any," since that was more common.
* Switch from "Check signatures" to "Check or an arbitrary software attack".