### PR TITLE
Specify in which order metadata should be published to the repository

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,8 +1,8 @@
 # <p align="center">The Update Framework Specification
 
-Last modified: **30 September 2020**
+Last modified: **06 October 2020**
 
-Version: **1.0.9**
+Version: **1.0.10**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an
@@ -461,6 +461,19 @@ repo](https://github.com/theupdateframework/specification/issues).
 
    Delegated target roles are authorized by the keys listed in the directly
    delegating target role.
+
+* **3.2 Repository metadata creation**
+
+   Metadata SHOULD be generated in the following sequence, in order to ensure
+   that metadata are not referenced in the repository before they have been
+   created.  The below sequence assumes that all targets files referenced by
+   the metadata are available to the repository before the metadata is written.
+
+     * **3.2.1** delegated targets metadata (DELEGATED_ROLE.EXT)
+     * **3.2.2** root metadata (root.EXT)
+     * **3.2.3** top-level targets metadata (targets.EXT)
+     * **3.2.4** snapshot metadata (snapshot.EXT)
+     * **3.2.5** timestamp metadata (timestamp.EXT)
 
 ## **4. Document formats**
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -468,12 +468,16 @@ repo](https://github.com/theupdateframework/specification/issues).
    that metadata are not referenced in the repository before they have been
    created.  The below sequence assumes that all targets files referenced by
    the metadata are available to the repository before the metadata is written.
+   When mirrors metadata is published by a repository it MAY be written at
+   any point after the initial metadata for the mirrored repository has been
+   created.
 
      * **3.2.1** delegated targets metadata (DELEGATED_ROLE.EXT)
      * **3.2.2** root metadata (root.EXT)
      * **3.2.3** top-level targets metadata (targets.EXT)
      * **3.2.4** snapshot metadata (snapshot.EXT)
      * **3.2.5** timestamp metadata (timestamp.EXT)
+     * **3.2.6** mirrors metadata (mirrors.EXT)
 
 ## **4. Document formats**
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -17,7 +17,7 @@ repo](https://github.com/theupdateframework/specification/issues).
 - [2. System Overview](#2-system-overview)
 - [3. The Repository](#3-the-repository)
 - [4. Document Formats](#4-document-formats)
-- [5. Detailed Workflows](#5-detailed-workflows)
+- [5. Detailed Client Workflow](#5-detailed-client-workflow)
 - [6. Usage](#6-usage)
 - [7. Consistent Snapshots](#7-consistent-snapshots)
 - [F. Future Directions and Open Questions](#f-future-directions-and-open-questions)
@@ -1064,9 +1064,7 @@ repo](https://github.com/theupdateframework/specification/issues).
    This behavior can be modified by the client code that uses the framework to,
    for example, randomly select from the listed mirrors.
 
-## **5. Detailed Workflows**
-
-### **The client application**
+## **5. Detailed Client Workflow**
 
   Note: If a step in the following workflow does not succeed (e.g., the update
   is aborted because a new metadata file was not signed), the client should


### PR DESCRIPTION
Include the recommended metadata write order, as detailed in PEP 458, in a new sub-section 3.2.

This is purposefully quite a small addition, with the idea of including more detailed workflows/recommendations in the proposed secondary literature #91

Fixes #105 