### PR TITLE
Minor clean-ups

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1309,7 +1309,7 @@ snapshot metadata file.
   (e.g.,
   c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681.foobar.tar.gz),
   where HASH is one of the hashes of the targets file listed in the targets
-  metadata file found earlier in step 4.  In either case, the client MUST write
+  metadata file found earlier in step 5.4.  In either case, the client MUST write
   the file to non-volatile storage as FILENAME.EXT.
 
 ## **6. Usage**

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -14,13 +14,13 @@ repo](https://github.com/theupdateframework/specification/issues).
 
 ## Table of Contents ##
 - [1. Introduction](#1-introduction)
-- [2. System Overview](#2-system-overview)
-- [3. The Repository](#3-the-repository)
-- [4. Document Formats](#4-document-formats)
-- [5. Detailed Workflows](#5-detailed-workflows)
+- [2. System overview](#2-system-overview)
+- [3. The repository](#3-the-repository)
+- [4. Document formats](#4-document-formats)
+- [5. Detailed workflows](#5-detailed-workflows)
 - [6. Usage](#6-usage)
-- [7. Consistent Snapshots](#7-consistent-snapshots)
-- [F. Future Directions and Open Questions](#f-future-directions-and-open-questions)
+- [7. Consistent snapshots](#7-consistent-snapshots)
+- [F. Future directions and open questions](#f-future-directions-and-open-questions)
 
 ## **1. Introduction**
 * **1.1. Scope**
@@ -282,7 +282,7 @@ repo](https://github.com/theupdateframework/specification/issues).
    All roles can use one or more keys and require a threshold of signatures of
    the role's keys in order to trust a given metadata file.
 
-  - **2.1.1. Root Role**
+  - **2.1.1. Root role**
 
       + The root role delegates trust to specific keys trusted for all other
    top-level roles used in the system.
@@ -353,7 +353,7 @@ repo](https://github.com/theupdateframework/specification/issues).
       security from being tricked into contacting the wrong mirrors.  This is
       because the framework has very little trust in repositories.
 
-* **2.2. Threat Model And Analysis**
+* **2.2. Threat model and analysis**
 
    We assume an adversary who can respond to client requests, whether by acting
    as a man-in-the-middle or through compromising repository mirrors.  At
@@ -1064,7 +1064,7 @@ repo](https://github.com/theupdateframework/specification/issues).
    This behavior can be modified by the client code that uses the framework to,
    for example, randomly select from the listed mirrors.
 
-## **5. Detailed Workflows**
+## **5. Detailed workflows**
 
 ### **The client application**
 
@@ -1357,7 +1357,7 @@ snapshot metadata file.
    just replaces that key with another in the signed metadata where the
    delegation is done.
 
-## **7. Consistent Snapshots**
+## **7. Consistent snapshots**
 
    So far, we have considered a TUF repository that is relatively static (in
    terms of how often metadata and target files are updated). The problem is

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,8 +1,8 @@
 # <p align="center">The Update Framework Specification
 
-Last modified: **30 September 2020**
+Last modified: **06 October 2020**
 
-Version: **1.0.10**
+Version: **1.0.11**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an


### PR DESCRIPTION
Fix a cross-reference and use consistent capitalisation for all titles.

I put the version and date bump in a separate patch, as it is not clear to me whether it is required for these very minor tweaks.