### PR TITLE
Fix METAFILES definition to match the text

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,8 +1,8 @@
 # <p align="center">The Update Framework Specification
 
-Last modified: **25 November 2020**
+Last modified: **1 December 2020**
 
-Version: **1.0.13**
+Version: **1.0.14**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an
@@ -734,8 +734,8 @@ repo](https://github.com/theupdateframework/specification/issues).
 
        { METAPATH : {
              "version" : VERSION,
-             ("length" : LENGTH, |
-              "hashes" : HASHES) }
+             ("length" : LENGTH,)
+             ("hashes" : HASHES) }
          , ...
        }
 


### PR DESCRIPTION
The text makes it clear that both "length" and "hashes" are optional and
not dependent on each other. The object format seems to imply that
both should not be included at the same time: DELEGATIONS uses the same
construct to express exactly that.

Express more clearly that the attributes are not dependent on each
other.

---
Fixes #134 