### PR TITLE
Initial conversion of the specification to bikeshed flavoured Markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tuf-spec.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+SHELL=/bin/bash -o pipefail
+.PHONY: local
+
+local: tuf-spec.md
+	bikeshed spec tuf-spec.md tuf-spec.html --md-Text-Macro="COMMIT-SHA LOCAL COPY"

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ SHELL=/bin/bash -o pipefail
 .PHONY: local
 
 local: tuf-spec.md
-	bikeshed spec tuf-spec.md tuf-spec.html --md-Text-Macro="COMMIT-SHA LOCAL COPY"
+	bikeshed spec tuf-spec.md tuf-spec.html

--- a/check_release.py
+++ b/check_release.py
@@ -30,11 +30,11 @@ import subprocess
 
 SPEC_NAME = "tuf-spec.md"
 
-LAST_MODIFIED_PATTERN = "Last modified: **%d %B %Y**\n"
-LAST_MODIFIED_LINENO = 3
+LAST_MODIFIED_PATTERN = "Date: %Y-%m-%d\n"
+LAST_MODIFIED_LINENO = 6
 
 VERSION_PATTERN = r"^Version: \*\*(\d*)\.(\d*)\.(\d*)\*\*$"
-VERSION_LINENO = 5
+VERSION_LINENO = 19
 
 class SpecError(Exception):
   """Common error message part. """

--- a/check_release.py
+++ b/check_release.py
@@ -33,7 +33,7 @@ SPEC_NAME = "tuf-spec.md"
 LAST_MODIFIED_PATTERN = "Date: %Y-%m-%d\n"
 LAST_MODIFIED_LINENO = 6
 
-VERSION_PATTERN = r"^Version: \*\*(\d*)\.(\d*)\.(\d*)\*\*$"
+VERSION_PATTERN = r"^Text Macro: VERSION (\d*)\.(\d*)\.(\d*)$"
 VERSION_LINENO = 19
 
 class SpecError(Exception):

--- a/header.include
+++ b/header.include
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <title>[TITLE]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style data-fill-with="stylesheet">
+  </style>
+</head>
+<body class="h-entry">
+<div class="head">
+  <p data-fill-with="logo"></p>
+  <h1 id="title" class="p-name no-ref">[TITLE]</h1>
+  <h2 id="subtitle" class="no-num no-toc no-ref"> Version: [VERSION] <br/>
+    Last modified: <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <div data-fill-with="spec-metadata"></div>
+  <div data-fill-with="warning"></div>
+  <p class='copyright' data-fill-with='copyright'></p>
+  <hr title="Separator for header">
+</div>
+
+<div data-fill-with="at-risk"></div>
+
+<nav data-fill-with="table-of-contents" id="toc"></nav>
+<main>

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -644,8 +644,8 @@ where:
 The <a for="role">KEYID</a> of a key is the hexdigest of the SHA-256 hash of
 the canonical form of the key.
 
-Metadata date-time data follows the ISO 8601 standard.  The expected format
-of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is
+Metadata <dfn>date-time</dfn> follows the ISO 8601 standard.  The expected
+format of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is
 always in UTC, and the "Z" time zone designator is attached to indicate a
 zero UTC offset.  An example date-time string is "1985-10-21T01:21:00Z".
 
@@ -688,8 +688,8 @@ where:
 
   : <dfn>SPEC_VERSION</dfn>
   ::
-    is a string that contains the version number of the TUF
-    specification. Its format follows the [Semantic Versioning 2.0.0
+    A string that contains the version number of the TUF
+    specification.  Its format follows the [Semantic Versioning 2.0.0
     (semver)](https://semver.org/spec/v2.0.0.html) specification. Metadata is
     written according to version "spec_version" of the specification, and
     clients MUST verify that "spec_version" matches the expected version number.
@@ -698,23 +698,24 @@ where:
 
   : <dfn>CONSISTENT_SNAPSHOT</dfn>
   ::
-    is a boolean indicating whether the repository supports
+    A boolean indicating whether the repository supports
     consistent snapshots.  Section 7 goes into more detail on the consequences
     of enabling this setting on a repository.
 
   : <dfn for="role">VERSION</dfn>
   ::
-    is an integer that is greater than 0.  Clients MUST NOT replace a
+    An integer that is greater than 0.  Clients MUST NOT replace a
     metadata file with a version number less than the one currently trusted.
 
   : <dfn>EXPIRES</dfn>
   ::
-    determines when metadata should be considered expired and no longer
-    trusted by clients.  Clients MUST NOT trust an expired file.
+    A <a>date-time</a> string indicating when metadata should be considered
+    expired and no longer trusted by clients.  Clients MUST NOT trust an
+    expired file.
 
   : <dfn for="root">ROLE</dfn>
   ::
-    is one of "root", "snapshot", "targets", "timestamp", or "mirrors".
+    One of "root", "snapshot", "targets", "timestamp", or "mirrors".
     A role for each of "root", "snapshot", "timestamp", and "targets" MUST be
     specified in the key list. The role of "mirror" is OPTIONAL.  If not
     specified, the mirror list will not need to be signed if mirror lists are
@@ -722,16 +723,16 @@ where:
 
   : <dfn for="root">KEYID</dfn>
   ::
-    The KEYID MUST be correct for the specified KEY.  Clients MUST calculate
-    each KEYID to verify this is correct for the associated key.  Clients MUST
-    ensure that for any KEYID represented in this key list and in other files,
-    only one unique key has that KEYID.
+    A <a for="role">KEYID</a>, which MUST be correct for the specified KEY.
+    Clients MUST calculate each <a for="role">KEYID</a> to verify this is
+    correct for the associated key.  Clients MUST ensure that for any
+    <a for="role">KEYID</a> represented in this key list and in other files,
+    only one unique key has that <a for="role">KEYID</a>.
 
   : <dfn>THRESHOLD</dfn>
   ::
-    The THRESHOLD for a role is an integer of the number of keys of that role
-    whose signatures are required in order to consider a file as being properly
-    signed by that role.
+    An integer number of keys of that role whose signatures are required in
+    order to consider a file as being properly signed by that role.
 
 <div class='example' id='example-root.json'>
 A <a>root.json</a> example file:
@@ -837,7 +838,7 @@ as is described for the <a>root.json</a> file.
 
 <pre highlight="json">
 {
-  <a>METAPATH</a> : {
+  <a for="snapshot">METAPATH</a> : {
       "version" : <a for="metapath">VERSION</a>,
       ("length" : <a for="metapath">LENGTH</a>,)
       ("hashes" : <a for="metapath">HASHES</a>)
@@ -848,31 +849,35 @@ as is described for the <a>root.json</a> file.
 
 where:
 
-  : <dfn>METAPATH</dfn>
+  : <dfn for="snapshot">METAPATH</dfn>
   ::
-    the file path of the metadata on the repository relative to the
-    metadata base URL. For snapshot.json, these are top-level targets metadata
-    and delegated targets metadata.
+    A string giving the file path of the metadata on the repository relative to
+    the metadata base URL.  For snapshot.json, these are top-level targets
+    metadata and delegated targets metadata.
 
   : <dfn for="metapath">VERSION</dfn>
   ::
-    the integer version number as shown in the metadata file at <a>METAPATH</a>.
+    An integer version number as shown in the metadata file at
+    <a for="snapshot">METAPATH</a>.
 
   : <dfn for="metapath">LENGTH</dfn>
   ::
-    the integer length in bytes of the metadata file at <a>METAPATH</a>. It
-    is OPTIONAL and can be omitted to reduce the snapshot metadata file size. In
-    that case the client MUST use a custom download limit for the listed
-    metadata.
+    An integer length in bytes of the metadata file at
+    <a for="snapshot">METAPATH</a>. It is OPTIONAL and can be omitted to reduce
+    the snapshot metadata file size.  In that case the client MUST use a custom
+    download limit for the listed metadata.
 
   : <dfn for="metapath">HASHES</dfn>
   ::
-    a dictionary that specifies one or more hashes of the metadata
-    file at <a>METAPATH</a>, including their cryptographic hash function. For
-    example: { "sha256": HASH, ... }. HASHES is OPTIONAL and can be omitted to
-    reduce the snapshot metadata file size.  In that case the repository MUST
-    guarantee that <a for="metapath">VERSION</a> alone unambiguously identifies
-    the metadata at <a>METAPATH</a>.
+    A dictionary that specifies one or more hashes of the metadata
+    file at <a for="snapshot">METAPATH</a>, with the cryptographic hash
+    function as key and the value as <dfn>HASH</dfn>, the hexdigest of the
+    cryptographic function computed on the metadata file at
+    <a for="snapshot">METAPATH</a>.  For example: `{ "sha256": HASH, ... }`.
+    <a for="metapath">HASHES</a> is OPTIONAL and can be omitted to reduce the
+    snapshot metadata file size.  In that case the repository MUST guarantee
+    that <a for="metapath">VERSION</a> alone unambiguously identifies
+    the metadata at <a for="snapshot">METAPATH</a>.
 
 <div class="example" id="example-snapshot.json">
 A <a>snapshot.json</a> example file:
@@ -948,40 +953,42 @@ where:
 
   : <a for="targets-obj">TARGETS</a>
   ::
-    Each key of the TARGETS object is a TARGETPATH.
+    Each key of the TARGETS object is a <a>TARGETPATH</a>.
 
   : <dfn>TARGETPATH</dfn>
   ::
-    a path to a file that is relative to a mirror's base URL of targets.
-    To avoid surprising behavior when resolving paths, it is RECOMMENDED that
-    a TARGETPATH uses the forward slash (/) as directory separator and does not
-    start with a directory separator. The recommendation for TARGETPATH aligns
-    with the ["path-relative-URL string"
+    A string giving the path to a file that is relative to a mirror's base URL
+    of targets.  To avoid surprising behavior when resolving paths, it is
+    RECOMMENDED that a <a>TARGETPATH</a> uses the forward slash (/) as directory
+    separator and does not start with a directory separator. The recommendation
+    for <a>TARGETPATH</a> aligns with the ["path-relative-URL string"
     definition](https://url.spec.whatwg.org/#path-relative-url-string) in the
     WHATWG URL specification.
 
-    It is allowed to have a <a>TARGETS</a> object with no TARGETPATH elements.  This
-    can be used to indicate that no target files are available.
+    It is allowed to have a <a>TARGETS</a> object with no <a>TARGETPATH</a>
+    elements.  This can be used to indicate that no target files are available.
 
   : <dfn for="targets-obj">LENGTH</dfn>
   ::
-    the integer length in bytes of the target file at <a>TARGETPATH</a>.
+    An integer length in bytes of the target file at <a>TARGETPATH</a>.
 
   : <dfn for="targets-obj">HASHES</dfn>
   ::
-    a dictionary that specifies one or more hashes, including the
-    cryptographic hash function.  For example: { "sha256": HASH, ... }. HASH is
-    the hexdigest of the cryptographic function computed on the target file.
+    A dictionary that specifies one or more hashes of the target file at
+    <a>TARGETPATH</a>, with a string describing the cryptographic hash function
+    as key and <a>HASH</a> as defined for <a>METAFILES</a>.  For example:
+    `{ "sha256": HASH, ... }`.
 
   : <dfn>CUSTOM</a>
   ::
-    If defined, the elements and values of the CUSTOM object will be made
-    available to the client application.  The format of the CUSTOM object is
-    opaque to the framework, which only needs to know that the "custom"
-    attribute maps to an object.  The CUSTOM object may include version
-    numbers, dependencies, requirements, or any other data that the application
-    wants to include to describe the file at <a>TARGETPATH</a>.  The
-    application may use this information to guide download decisions.
+    An object.  If defined, the elements and values of the <a>CUSTOM</a> object
+    will be made available to the client application.  The format of the
+    <a>CUSTOM</a> object is opaque to the framework, which only needs to know
+    that the "custom" attribute maps to an object.  The <a>CUSTOM</a> object
+    may include version numbers, dependencies, requirements, or any other data
+    that the application wants to include to describe the file at
+    <a>TARGETPATH</a>.  The application may use this information to guide
+    download decisions.
 
 <dfn>DELEGATIONS</dfn> is an object whose format is the following:
 
@@ -1009,17 +1016,18 @@ where:
 
   : "keys"
   ::
-    lists the public keys to verify signatures of delegated targets roles.
+    A list of <a for="role">KEYID</a>'s identifying the public keys to verify
+    signatures of delegated targets roles.
     Revocation and replacement of delegated targets roles keys is done by
     changing the keys in this field in the delegating role's metadata.
 
   : <dfn>ROLENAME</dfn>
   ::
-    the name of the delegated role.  For example, "projects".
+    A string giving the name of the delegated role.  For example, "projects".
 
   : <dfn>TERMINATING</dfn>
   ::
-    a boolean indicating whether subsequent delegations should be considered.
+    A boolean indicating whether subsequent delegations should be considered.
 
     As explained in the [Diplomat
     paper](https://github.com/theupdateframework/tuf/blob/develop/docs/papers/protect-community-repositories-nsdi2016.pdf),
@@ -1031,36 +1039,38 @@ where:
     ignored.
 
 In order to discuss target paths, a role MUST specify only one of the
-"path_hash_prefixes" or "paths" attributes, each of which we discuss next.
+<a>"path_hash_prefixes"</a> or <a>"paths"</a> attributes, each of which we
+discuss next.
 
-  : "path_hash_prefixes"
+  : <dfn>"path_hash_prefixes"</dfn>
   ::
-    The "path_hash_prefixes" list is used to succinctly describe a set of target
-    paths. Specifically, each HEX_DIGEST in "path_hash_prefixes" describes a set
-    of target paths; therefore, "path_hash_prefixes" is the union over each
-    prefix of its set of target paths. The target paths must meet this
-    condition: each target path, when hashed with the SHA-256 hash function to
-    produce a 64-byte hexadecimal digest (HEX_DIGEST), must share the same
-    prefix as one of the prefixes in "path_hash_prefixes". This is useful to
-    split a large number of targets into separate bins identified by consistent
-    hashing.
+    A list of HEX_DIGESTs used to succinctly describe a set of target
+    paths. Specifically, each HEX_DIGEST in <a>"path_hash_prefixes"</a>
+    describes a set of target paths; therefore, <a>"path_hash_prefixes"</a> is
+    the union over each prefix of its set of target paths.  The target paths
+    must meet this condition: each target path, when hashed with the SHA-256
+    hash function to produce a 64-byte hexadecimal digest
+    (HEX_DIGEST), must share the same prefix as one of the prefixes
+    in <a>"path_hash_prefixes"</a>.  This is useful to split a large number of
+    targets into separate bins identified by consistent hashing.
 
-  : "paths"
+  : <dfn>"paths"</dfn>
   ::
-    The "paths" list describes paths that the role is trusted to provide.
-    Clients MUST check that a target is in one of the trusted paths of all roles
-    in a delegation chain, not just in a trusted path of the role that describes
-    the target file.  PATHPATTERN can include shell-style wildcards and supports
-    the Unix filename pattern matching convention.  Its format may either
-    indicate a path to a single file, or to multiple paths with the use of
-    shell-style wildcards.  For example, the path pattern "targets/*.tgz" would
-    match file paths "targets/foo.tgz" and "targets/bar.tgz", but not
-    "targets/foo.txt".  Likewise, path pattern "foo-version-?.tgz" matches
-    "foo-version-2.tgz" and "foo-version-a.tgz", but not "foo-version-alpha.tgz".
-    To avoid surprising behavior when matching targets with PATHPATTERN, it is
-    RECOMMENDED that PATHPATTERN uses the forward slash (/) as directory
-    separator and does not start with a directory separator, akin to
-    TARGETSPATH.
+    A list of strings, where each string describe paths that the role is
+    trusted to provide.  Clients MUST check that a target is in one of the
+    trusted paths of all roles in a delegation chain, not just in a trusted
+    path of the role that describes the target file.  <dfn>PATHPATTERN</dfn>
+    can include shell-style wildcards and supports the Unix filename pattern
+    matching convention.  Its format may either indicate a path to a single
+    file, or to multiple paths with the use of shell-style wildcards.  For
+    example, the path pattern "targets/*.tgz" would match file paths
+    "targets/foo.tgz" and "targets/bar.tgz", but not "targets/foo.txt".
+    Likewise, path pattern "foo-version-?.tgz" matches "foo-version-2.tgz" and
+    "foo-version-a.tgz", but not "foo-version-alpha.tgz".
+    To avoid surprising behavior when matching targets with <a>PATHPATTERN</a>,
+    it is RECOMMENDED that <a>PATHPATTERN</a> uses the forward slash (/) as
+    directory separator and does not start with a directory separator, akin to
+    <a>TARGETPATH</a>.
 
 
 Prioritized delegations allow clients to resolve conflicts between delegated
@@ -1210,25 +1220,35 @@ The "signed" portion of <a>mirrors.json</a> is as follows:
   "expires" : <a>EXPIRES</a>,
   "mirrors" : [
     { "urlbase" : <a>URLBASE</a>,
-      "metapath" : <a>METAPATH</a>,
+      "metapath" : <a for="mirrors">METAPATH</a>,
       "targetspath" : TARGETSPATH,
-      "metacontent" : [ PATHPATTERN ... ] ,
-      "targetscontent" : [ PATHPATTERN ... ] ,
+      "metacontent" : [ <a>PATHPATTERN</a> ... ] ,
+      "targetscontent" : [ <a>PATHPATTERN</a> ... ] ,
       ("custom" : { ... }) }
     , ... ]
 }
 </pre>
+
+where:
 
 <a>SPEC_VERSION</a>, <a for="role">VERSION</a> and <a>EXPIRES</a> are the same
 as is described for the <a>root.json</a> file.
 
   : <dfn>URLBASE</dfn>
   ::
-    the URL of the mirror which <a>METAPATH</a> and TARGETSPATH are relative
-    to.  All metadata files will be retrieved from <a>METAPATH</a> and all target files
-    will be retrieved from TARGETSPATH.
+    A string giving the URL of the mirror.
 
-The lists of PATHPATTERN for "metacontent" and "targetscontent" describe the
+  : <dfn for="mirrors">METAPATH</dfn>
+  ::
+    A string giving the location from which to retrieve metadata files.
+    <a for="mirrors">METAPATH</a> will be a relative path to <a>URLBASE</a>.
+
+  : <dfn>TARGETSPATH</a>
+  ::
+    A string giving the location from which to retrieve target files.
+    <a>TARGETSPATH</a> will be a relative path to <a>URLBASE</a>.
+
+The lists of <a>PATHPATTERN</a> for "metacontent" and "targetscontent" describe the
 metadata files and target files available from the mirror.
 
 The order of the list of mirrors is important.  For any file to be

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -556,7 +556,7 @@ where:
       : <dfn>SCHEME</dfn>
       ::
         a string denoting a corresponding signature scheme.  For example: <a
-        for="scheme">"rsassa-pss-sha256"</a>, <a for="scheme">"ed25519"</a> <a
+        for="scheme">"rsassa-pss-sha256"</a>, <a for="scheme">"ed25519"</a>, and <a
         for="scheme">"ecdsa-sha2-nistp256"</a>.
 
       : <dfn>KEYVAL</dfn>
@@ -1019,7 +1019,7 @@ where:
 
   : "keys"
   ::
-    A list of <a for="role">KEYID</a>'s identifying the public keys to verify
+    A list of <a for="role">KEYID</a>s identifying the public keys to verify
     signatures of delegated targets roles.
     Revocation and replacement of delegated targets roles keys is done by
     changing the keys in this field in the delegating role's metadata.
@@ -1059,7 +1059,7 @@ discuss next.
 
   : <dfn>"paths"</dfn>
   ::
-    A list of strings, where each string describe paths that the role is
+    A list of strings, where each string describes a path that the role is
     trusted to provide.  Clients MUST check that a target is in one of the
     trusted paths of all roles in a delegation chain, not just in a trusted
     path of the role that describes the target file.  <dfn>PATHPATTERN</dfn>

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -215,7 +215,7 @@ when a client is unable to update.
 
 ### TUF Augmentation Proposal (TAP) support ### {#tuf-augmentation-proposal-tap-support}
 
-This version (1.0.0) of the specification adheres to the following TAPS:
+This major version (1.x.y) of the specification adheres to the following TAPS:
 
 - [TAP 6](https://github.com/theupdateframework/taps/blob/master/tap6.md):
     Include specification version in metadata
@@ -226,7 +226,7 @@ This version (1.0.0) of the specification adheres to the following TAPS:
 - [TAP 11](https://github.com/theupdateframework/taps/blob/master/tap11.md):
     Using POUFs for Interoperability
 
-Implementations compliant with this version (1.0.0) of the specification
+Implementations compliant with this major version (1.x.y) of the specification
 must also comply with the TAPs mentioned above.
 
 # System overview # {#system-overview}

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -534,7 +534,7 @@ All signed metadata objects have the format:
         A hex-encoded signature of the canonical form of the metadata for <a for="role">ROLE</a>.
 
 
-All keys have the format:
+All <dfn>KEY</dfn>s have the format:
 
 <pre highlight="json">
 {
@@ -662,7 +662,7 @@ The "signed" portion of <a>root.json</a> is as follows:
   "version" : <a for="role">VERSION</a>,
   "expires" : <a>EXPIRES</a>,
   "keys" : {
-    <a for="root">KEYID</a> : KEY,
+    <a for="root">KEYID</a> : <a>KEY</a>,
     ...
   },
   "roles" : {
@@ -983,7 +983,7 @@ as is described for the <a>root.json</a> file.
 <pre highlight="json">
 {
   "keys" : {
-      <a for="role">KEYID</a> : KEY,
+      <a for="role">KEYID</a> : <a>KEY</a>,
       ...
   },
   "roles" : [

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,16 +1,20 @@
-<pre class=metadata>
-Status: DREAM
-Shortname: tuf
-Abstract: todo
-Group: tuf
+<pre class='metadata'>
 Title: The Update Framework Specification
-Editor: foo
+Shortname: TUF
+Status: LS-COMMIT
+Abstract: A framework for securing software update systems.
+Date: 2020-12-03
+Editor: Justin Cappos, NYU
+Editor: Trishank Karthik Kuppusamy, Datadog
+Editor: Joshua Lock, VMware
+Editor: Marina Moore, NYU
+Editor: Lukas Pühringer, NYU
+Repository: theupdateframework/specification
+Mailing List: https://groups.google.com/forum/?fromgroups#!forum/theupdateframework
 Indent: 2
-Boilerplate: copyright no
+Boilerplate: copyright no, conformance no
 Markup Shorthands: css no, markdown yes
 </pre>
-
-Last modified: **3 December 2020**
 
 Version: **1.0.16**
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1296,10 +1296,10 @@ it in the next step.
   reached.  Therefore, it MUST temporarily turn on consistent snapshots in
   order to download *versioned* root metadata files as described next.
 
-1. Let N denote the version number of the trusted root metadata
+2. Let N denote the version number of the trusted root metadata
   file.
 
-1. **Try downloading version N+1 of the root metadata file**, up to
+3. **Try downloading version N+1 of the root metadata file**, up to
   some W number of bytes (because the size is unknown). The value for W is set
   by the authors of the application using TUF. For example, W may be tens of
   kilobytes. The filename used to download the root metadata file is of the
@@ -1309,7 +1309,7 @@ it in the next step.
   The value for Y is set by the authors of the application using TUF. For
   example, Y may be 2^10.
 
-1. **Check for an arbitrary software attack.** Version N+1 of the root
+4. **Check for an arbitrary software attack.** Version N+1 of the root
   metadata file MUST have been signed by: (1) a threshold of keys specified in
   the trusted root metadata file (version N), and (2) a threshold of keys
   specified in the new root metadata file being validated (version N+1).  If
@@ -1317,7 +1317,7 @@ it in the next step.
   and report the signature failure.  On the next update cycle, begin at step
   [[#update-root]] and version N of the root metadata file.
 
-1. **Check for a rollback attack.** The version number of the trusted
+5. **Check for a rollback attack.** The version number of the trusted
   root metadata file (version N) MUST be less than or equal to the version
   number of the new root metadata file (version N+1). Effectively, this means
   checking that the version number signed in the new root metadata file is
@@ -1326,24 +1326,24 @@ it in the next step.
   rollback attack.  On the next update cycle, begin at step [[#update-root]]
   and version N of the root metadata file.
 
-1. Note that the expiration of the new (intermediate) root metadata
+6. Note that the expiration of the new (intermediate) root metadata
   file does not matter yet, because we will check for it in step 5.3.10.
 
-1. **Set the trusted root metadata file** to the new root metadata
+7. **Set the trusted root metadata file** to the new root metadata
   file.
 
-1. **Persist root metadata.** The client MUST write the file to
+8. **Persist root metadata.** The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. root.json).
 
-1. Repeat steps 5.3.1 to 5.3.8
+9. Repeat steps 5.3.1 to 5.3.8
 
-1. **Check for a freeze attack.** The expiration timestamp in the
+10. **Check for a freeze attack.** The expiration timestamp in the
   trusted root metadata file MUST be higher than the fixed update start time.
   If the trusted root metadata file has expired, abort the update cycle,
   report the potential freeze attack.  On the next update cycle, begin at step
   5.1 and version N of the root metadata file.
 
-1. **If the timestamp and / or snapshot keys have been rotated, then delete the
+11. **If the timestamp and / or snapshot keys have been rotated, then delete the
   trusted timestamp and snapshot metadata files.** This is done
   in order to recover from fast-forward attacks after the repository has been
   compromised and recovered. A _fast-forward attack_ happens when attackers
@@ -1353,7 +1353,7 @@ it in the next step.
   paper](https://theupdateframework.io/papers/prevention-rollback-attacks-atc2017.pdf)
   for more details.
 
-1. **Set whether consistent snapshots are used as per the trusted**
+12. **Set whether consistent snapshots are used as per the trusted**
     root metadata file (see [[#file-formats-root]]).
 
 ## Update the timestamp role ## {#update-timestamp}
@@ -1364,13 +1364,13 @@ it in the next step.
   used to download the timestamp metadata file is of the fixed form FILENAME.EXT
   (e.g., timestamp.json).
 
-1. **Check for an arbitrary software attack.** The new timestamp
+2. **Check for an arbitrary software attack.** The new timestamp
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new timestamp metadata file is not
   properly signed, discard it, abort the update cycle, and report the signature
   failure.
 
-1. **Check for a rollback attack.**
+3. **Check for a rollback attack.**
 
   1. The version number of the trusted timestamp metadata file, if
     any, MUST be less than or equal to the version number of the new timestamp
@@ -1378,18 +1378,18 @@ it in the next step.
     trusted timestamp metadata file, discard it, abort the update cycle, and
     report the potential rollback attack.
 
-  1. The version number of the snapshot metadata file in the
+  2. The version number of the snapshot metadata file in the
     trusted timestamp metadata file, if any, MUST be less than or equal to its
     version number in the new timestamp metadata file.  If not, discard the new
     timestamp metadata file, abort the update cycle, and report the failure.
 
-1. **Check for a freeze attack.** The expiration timestamp in the
+4. **Check for a freeze attack.** The expiration timestamp in the
   new timestamp metadata file MUST be higher than the fixed update start time.
   If so, the new timestamp metadata file becomes the trusted timestamp
   metadata file.  If the new timestamp metadata file has expired, discard it,
   abort the update cycle, and report the potential freeze attack.
 
-1. **Persist timestamp metadata**. The client MUST write the file
+5. **Persist timestamp metadata**. The client MUST write the file
   to non-volatile storage as FILENAME.EXT (e.g. timestamp.json).
 
 ## Update the snapshot role ## {#update-snapshot}
@@ -1405,25 +1405,25 @@ it in the next step.
   the version number of the snapshot metadata file listed in the timestamp
   metadata file.
 
-1. **Check against timestamp role's snapshot hash**. The hashes
+2. **Check against timestamp role's snapshot hash**. The hashes
   of the new snapshot metadata file MUST match the hashes, if any, listed in
   the trusted timestamp metadata.  This is done, in part, to prevent a
   mix-and-match attack by man-in-the-middle attackers.  If the hashes do not
   match, discard the new snapshot metadata, abort the update cycle, and report
   the failure.
 
-1. **Check for an arbitrary software attack**. The new snapshot
+3. **Check for an arbitrary software attack**. The new snapshot
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new snapshot metadata file is not signed
   as required, discard it, abort the update cycle, and report the signature
   failure.
 
-1. **Check against timestamp role's snapshot version**. The version
+4. **Check against timestamp role's snapshot version**. The version
   number of the new snapshot metadata file MUST match the version number listed
   in the trusted timestamp metadata.  If the versions do not match, discard the
   new snapshot metadata, abort the update cycle, and report the failure.
 
-1. **Check for a rollback attack**. The version number of the targets
+5. **Check for a rollback attack**. The version number of the targets
   metadata file, and all delegated targets metadata files, if any, in the
   trusted snapshot metadata file, if any, MUST be less than or equal to its
   version number in the new snapshot metadata file. Furthermore, any targets
@@ -1432,14 +1432,14 @@ it in the next step.
   these conditions are not met, discard the new snapshot metadata file, abort
   the update cycle, and report the failure.
 
-1. **Check for a freeze attack**. The expiration timestamp in the
+6. **Check for a freeze attack**. The expiration timestamp in the
   new snapshot metadata file MUST be higher than the fixed update start time.
   If so, the new snapshot metadata file becomes the trusted snapshot metadata
   file.  If the new snapshot metadata file is expired, discard it, abort the
   update cycle, and report the potential freeze attack.
 
 
-1. **Persist snapshot metadata**. The client MUST write the file to
+7. **Persist snapshot metadata**. The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. snapshot.json).
 
 ## Update the targets role ## {#update-targets}
@@ -1454,33 +1454,33 @@ it in the next step.
   42.targets.json), where VERSION_NUMBER is the version number of the targets
   metadata file listed in the snapshot metadata file.
 
-1. **Check against snapshot role's targets hash**. The hashes
+2. **Check against snapshot role's targets hash**. The hashes
   of the new targets metadata file MUST match the hashes, if any, listed in the
   trusted snapshot metadata.  This is done, in part, to prevent a mix-and-match
   attack by man-in-the-middle attackers.  If the new targets metadata file does
   not match, discard the new target metadata, abort the update cycle, and
   report the failure.
 
-1. **Check for an arbitrary software attack**. The new targets
+3. **Check for an arbitrary software attack**. The new targets
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new targets metadata file is not signed
   as required, discard it, abort the update cycle, and report the failure.
 
-1. **Check against snapshot role's targets version**. The version
+4. **Check against snapshot role's targets version**. The version
   number of the new targets metadata file MUST match the version number listed
   in the trusted snapshot metadata.  If the versions do not match, discard it,
   abort the update cycle, and report the failure.
 
-1. **Check for a freeze attack**. The expiration timestamp in the
+5. **Check for a freeze attack**. The expiration timestamp in the
   new targets metadata file MUST be higher than the fixed update start time.
   If so, the new targets metadata file becomes the trusted targets metadata
   file.  If the new targets metadata file is expired, discard it, abort the
   update cycle, and report the potential freeze attack.
 
-1. **Persist targets metadata**. The client MUST write the file to
+6. **Persist targets metadata**. The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. targets.json).
 
-1. **Perform a pre-order depth-first search for metadata about the
+7. **Perform a pre-order depth-first search for metadata about the
   desired target, beginning with the top-level targets role.** Note: If
   any metadata requested in steps 5.6.7.1 - 5.6.7.2 cannot be downloaded nor
   validated, end the search and report that the target cannot be found.
@@ -1492,7 +1492,7 @@ it in the next step.
      bandwidth or time).  Otherwise, if this role contains metadata about the
      desired target, then go to step [[#fetch-target]].
 
-  1. Otherwise, recursively search the list of delegations in
+  2. Otherwise, recursively search the list of delegations in
      order of appearance.
 
     1. If the current delegation is a multi-role delegation,
@@ -1500,10 +1500,10 @@ it in the next step.
        same non-custom metadata (i.e., length and hashes) about the target (or
        the lack of any such metadata).
 
-    1. If the current delegation is a terminating delegation,
+    2. If the current delegation is a terminating delegation,
        then jump to step [[#fetch-target]].
 
-    1. Otherwise, if the current delegation is a
+    3. Otherwise, if the current delegation is a
        non-terminating delegation, continue processing the next delegation, if
        any. Stop the search, and jump to step [[#fetch-target]] as soon as a delegation
        returns a result.
@@ -1512,10 +1512,10 @@ it in the next step.
 
 1. **Verify the desired target against its targets metadata**.
 
-1. If there is no targets metadata about this target, abort the
+2. If there is no targets metadata about this target, abort the
     update cycle and report that there is no such target.
 
-1. Otherwise, download the target (up to the number of bytes
+3. Otherwise, download the target (up to the number of bytes
    specified in the targets metadata), and verify that its hashes match the
    targets metadata. (We download up to this number of bytes, because in some
    cases, the exact number is unknown. This may happen, for example, if an

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Title: The Update Framework Specification
 Shortname: TUF
-Status: LS-COMMIT
+Status: LS
 Abstract: A framework for securing software update systems.
 Date: 2020-12-11
 Editor: Justin Cappos, NYU
@@ -13,10 +13,11 @@ Repository: theupdateframework/specification
 Mailing List: https://groups.google.com/forum/?fromgroups#!forum/theupdateframework
 Indent: 2
 Boilerplate: copyright no, conformance no
+Local Boilerplate: header yes
 Markup Shorthands: css no, markdown yes
+Metadata Include: This version off, Abstract off
+Text Macro: VERSION 1.0.17
 </pre>
-
-Version: **1.0.17**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1000,12 +1000,8 @@ as is described for the <a>root.json</a> file.
 }
 </pre>
 
-  : "keys"
-  ::
-    A list of <a for="role">KEYID</a>s identifying the public keys to verify
-    signatures of delegated targets roles.
-    Revocation and replacement of delegated targets roles keys is done by
-    changing the keys in this field in the delegating role's metadata.
+  <a for="root">KEYID</a> and <a>KEY</a> are the same as is described for the
+  <a>root.json</a> file.
 
   : <dfn>ROLENAME</dfn>
   ::

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1261,16 +1261,14 @@ matching paths will only be tried if downloading from earlier mirrors fails.
 This behavior can be modified by the client code that uses the framework to,
 for example, randomly select from the listed mirrors.
 
-# Detailed workflows # {#detailed-workflows}
-
-## The client application ## {#the-client-application}
+# Detailed client workflow # {#detailed-client-workflow}
 
 Note: If a step in the following workflow does not succeed (e.g., the update
 is aborted because a new metadata file was not signed), the client should
 still be able to update again in the future. Errors raised during the update
 process should not leave clients in an unrecoverable state.
 
-## Record the time at which the update began ## {#fix-time}
+## Record fixed update start time ## {#fix-time}
 
 Record the time at which the update began as the fixed update start time.
 Time is fixed at the beginning of the update workflow to allow
@@ -1278,7 +1276,7 @@ an application using TUF to effectively pause time, in order to ensure that
 metadata which has a valid expiration time at the beginning of an update
 does not fail an expiration check later in the update workflow.
 
-## Load the trusted root metadata file ## {#load-trusted-root}
+## Load trusted root metadata ## {#load-trusted-root}
 
 Load the trusted root metadata file.  We assume that a good,
 trusted copy of this file was shipped with the package manager or software

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -520,8 +520,6 @@ All signed metadata objects have the format:
 }
 </pre>
 
-where:
-
       : <dfn for="role">ROLE</dfn>
       ::
         a dictionary whose "_type" field describes the role type.
@@ -544,8 +542,6 @@ All keys have the format:
   "keyval" : <a>KEYVAL</a>
 }
 </pre>
-
-where:
 
       : <dfn>KEYTYPE</dfn>
       ::
@@ -602,8 +598,6 @@ The <dfn for="keytype">"rsa"</dfn> format is:
 }
 </pre>
 
-where:
-
   : <dfn for="keyval-rsa">PUBLIC</dfn>
   ::
     PEM format and a string.  All RSA keys MUST be at least 2048 bits.
@@ -620,8 +614,6 @@ The <dfn for="keytype">"ed25519"</dfn> format is:
 }
 </pre>
 
-where:
-
   : <dfn for="keyval-ed25519">PUBLIC</dfn>
   ::
     64-byte hex encoded string.
@@ -637,8 +629,6 @@ The <dfn for="keytype">"ecdsa-sha2-nistp256"</dfn> format is:
   }
 }
 </pre>
-
-where:
 
   : <dfn for="keyval-ecdsa">PUBLIC</dfn>
   ::
@@ -686,8 +676,6 @@ The "signed" portion of <a>root.json</a> is as follows:
   }
 }
 </pre>
-
-where:
 
   : <dfn>SPEC_VERSION</dfn>
   ::
@@ -850,8 +838,6 @@ as is described for the <a>root.json</a> file.
 }
 </pre>
 
-where:
-
   : <dfn for="snapshot">METAPATH</dfn>
   ::
     A string giving the file path of the metadata on the repository relative to
@@ -952,8 +938,6 @@ as is described for the <a>root.json</a> file.
 }
 </pre>
 
-where:
-
   : <a for="targets-obj">TARGETS</a>
   ::
     Each key of the <a for="targets-obj">TARGETS</a> object is a <a>TARGETPATH</a>.
@@ -1014,8 +998,6 @@ where:
   ]
 }
 </pre>
-
-where:
 
   : "keys"
   ::
@@ -1231,8 +1213,6 @@ The "signed" portion of <a>mirrors.json</a> is as follows:
     , ... ]
 }
 </pre>
-
-where:
 
 <a>SPEC_VERSION</a>, <a for="role">VERSION</a> and <a>EXPIRES</a> are the same
 as is described for the <a>root.json</a> file.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -991,7 +991,7 @@ as is described for the <a>root.json</a> file.
       "keyids" : [ <a for="role">KEYID</a>, ... ] ,
       "threshold" : <a>THRESHOLD</a>,
       (<a>"path_hash_prefixes"</a> : [ HEX_DIGEST, ... ] |
-      "<a>paths</a>" : [ <a>PATHPATTERN</a>, ... ]),
+      <a for="delegation-role">"paths"</a> : [ <a>PATHPATTERN</a>, ... ]),
       "terminating": <a>TERMINATING</a>,
     },
     ...
@@ -1024,7 +1024,7 @@ as is described for the <a>root.json</a> file.
     ignored.
 
 In order to discuss target paths, a role MUST specify only one of the
-<a>"path_hash_prefixes"</a> or <a>"paths"</a> attributes, each of which we
+<a>"path_hash_prefixes"</a> or <a for="delegation-role">"paths"</a> attributes, each of which we
 discuss next.
 
   : <dfn>"path_hash_prefixes"</dfn>
@@ -1039,7 +1039,7 @@ discuss next.
     in <a>"path_hash_prefixes"</a>.  This is useful to split a large number of
     targets into separate bins identified by consistent hashing.
 
-  : <dfn>"paths"</dfn>
+  : <dfn for="delegation-role">"paths"</dfn>
   ::
     A list of strings, where each string describes a path that the role is
     trusted to provide.  Clients MUST check that a target is in one of the
@@ -1321,7 +1321,7 @@ it in the next step.
   trusted root metadata file MUST be higher than the fixed update start time.
   If the trusted root metadata file has expired, abort the update cycle,
   report the potential freeze attack.  On the next update cycle, begin at step
- [[#update-root]] and version N of the root metadata file.
+  [[#update-root]] and version N of the root metadata file.
 
 11. **If the timestamp and / or snapshot keys have been rotated, then delete the
   trusted timestamp and snapshot metadata files.** This is done

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -3,7 +3,7 @@ Title: The Update Framework Specification
 Shortname: TUF
 Status: LS-COMMIT
 Abstract: A framework for securing software update systems.
-Date: 2020-12-03
+Date: 2020-12-11
 Editor: Justin Cappos, NYU
 Editor: Trishank Karthik Kuppusamy, Datadog
 Editor: Joshua Lock, VMware
@@ -16,7 +16,7 @@ Boilerplate: copyright no, conformance no
 Markup Shorthands: css no, markdown yes
 </pre>
 
-Version: **1.0.16**
+Version: **1.0.17**
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -522,15 +522,15 @@ All signed metadata objects have the format:
 
       : <dfn for="role">ROLE</dfn>
       ::
-        a dictionary whose "_type" field describes the role type.
+        A dictionary whose "_type" field describes the role type.
 
       : <dfn for="role">KEYID</dfn>
       ::
-        the identifier of the key signing the <a for="role">ROLE</a> dictionary.
+        The identifier of the key signing the <a for="role">ROLE</a> dictionary.
 
       : <dfn>SIGNATURE</dfn>
       ::
-        a hex-encoded signature of the canonical form of the metadata for <a for="role">ROLE</a>.
+        A hex-encoded signature of the canonical form of the metadata for <a for="role">ROLE</a>.
 
 
 All keys have the format:
@@ -545,19 +545,19 @@ All keys have the format:
 
       : <dfn>KEYTYPE</dfn>
       ::
-        a string denoting a public key signature system, such as <a
+        A string denoting a public key signature system, such as <a
         for="keytype">"rsa"</a>, <a for="keytype">"ed25519"</a>, and <a
         for="keytype">"ecdsa-sha2-nistp256"</a>.
 
       : <dfn>SCHEME</dfn>
       ::
-        a string denoting a corresponding signature scheme.  For example: <a
+        A string denoting a corresponding signature scheme.  For example: <a
         for="scheme">"rsassa-pss-sha256"</a>, <a for="scheme">"ed25519"</a>, and <a
         for="scheme">"ecdsa-sha2-nistp256"</a>.
 
       : <dfn>KEYVAL</dfn>
       ::
-        a dictionary containing the public portion of the key.
+        A dictionary containing the public portion of the key.
 
 The reference implementation defines three signature schemes, although TUF
 is not restricted to any particular signature scheme, key type, or

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1032,8 +1032,8 @@ where:
   ::
     A boolean indicating whether subsequent delegations should be considered.
 
-    As explained in the [Diplomat
-    paper](https://github.com/theupdateframework/tuf/blob/develop/docs/papers/protect-community-repositories-nsdi2016.pdf),
+    As explained in the [Diplomat paper
+    ](https://theupdateframework.io/papers/protect-community-repositories-nsdi2016.pdf),
     terminating delegations instruct the client not to consider future trust
     statements that match the delegation's pattern, which stops the delegation
     processing once this delegation (and its descendants) have been processed.
@@ -1351,7 +1351,7 @@ it in the next step.
   arbitrarily increase the version numbers of: (1) the timestamp metadata, (2)
   the snapshot metadata, and / or (3) the targets, or a delegated targets,
   metadata file in the snapshot metadata. Please see [the Mercury
-  paper](https://ssl.engineering.nyu.edu/papers/kuppusamy-mercury-usenix-2017.pdf)
+  paper](https://theupdateframework.io/papers/prevention-rollback-attacks-atc2017.pdf)
   for more details.
 
 1. **Set whether consistent snapshots are used as per the trusted**

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -60,7 +60,7 @@ Work on TUF began in late 2009.  The core ideas are based off of previous
 work done by Justin Cappos and Justin Samuel that [identified security flaws
 in all popular Linux package managers](https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf).
 More information and current versions of this document can be found at
-https://theupdateframework.io/
+[https://theupdateframework.io/](https://theupdateframework.io/)
 
 The [Global Environment for Network Innovations](https://www.geni.net/) (GENI)
 and the [National Science Foundation](https://www.nsf.gov/) (NSF) have
@@ -71,7 +71,8 @@ TUF's reference implementation is based on prior work on
 updater for Tor. Its design and this spec
 also came from ideas jointly developed in discussion with Thandy's authors.
 The Thandy spec can be found at
-https://gitweb.torproject.org/thandy.git/tree/specs/thandy-spec.txt
+[https://gitweb.torproject.org/thandy.git/tree/specs/thandy-spec.txt
+](https://gitweb.torproject.org/thandy.git/tree/specs/thandy-spec.txt)
 
 Whereas Thandy is an application updater for an individual software project,
 TUF aims to provide a way to secure any software update system. We're very
@@ -569,18 +570,20 @@ cryptographic library:
   : <dfn for="scheme">"rsassa-pss-sha256"</dfn>
   ::
     RSA Probabilistic signature scheme with appendix. The underlying hash
-    function is SHA256. https://tools.ietf.org/html/rfc3447#page-29
+    function is SHA256. [https://tools.ietf.org/html/rfc3447#page-29
+    ](https://tools.ietf.org/html/rfc3447#page-29)
 
   : <dfn for="scheme">"ed25519"</dfn>
   ::
     Elliptic curve digital signature algorithm based on Twisted Edwards curves.
-    https://ed25519.cr.yp.to/
+    [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/)
 
   : <dfn for="scheme">"ecdsa-sha2-nistp256"</dfn>
   ::
     Elliptic Curve Digital Signature Algorithm with NIST P-256 curve signing
     and SHA-256 hashing.
-    https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+    [https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+    ](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)
 
 We define three keytypes below: <a for="keytype">"rsa"</a>, <a
 for="keytype">"ed25519"</a>, and <a for="keytype">"ecdsa-sha2-nistp256"</a>, but adopters
@@ -1529,7 +1532,7 @@ it in the next step.
 
 # 6. Usage # {#usage}
 
-See [theupdateframework.io](https://theupdateframework.io/) for discussion of
+See [https://theupdateframework.io/](https://theupdateframework.io/) for discussion of
 recommended usage in various situations.
 
 ## Key management and migration ## {#key-management-and-migration}

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -991,7 +991,7 @@ as is described for the <a>root.json</a> file.
       "name": <a>ROLENAME</a>,
       "keyids" : [ <a for="role">KEYID</a>, ... ] ,
       "threshold" : <a>THRESHOLD</a>,
-      (<a>"path_hash_prefixes"</a> : [ HEX_DIGEST, ... ] |
+      (<a>"path_hash_prefixes"</a> : [ <a>HEX_DIGEST</a>, ... ] |
       <a for="delegation-role">"paths"</a> : [ <a>PATHPATTERN</a>, ... ]),
       "terminating": <a>TERMINATING</a>,
     },
@@ -1026,7 +1026,7 @@ discuss next.
 
   : <dfn>"path_hash_prefixes"</dfn>
   ::
-    A list of HEX_DIGESTs used to succinctly describe a set of target
+    A list of <dfn>HEX_DIGEST</dfn>s used to succinctly describe a set of target
     paths. Specifically, each HEX_DIGEST in <a>"path_hash_prefixes"</a>
     describes a set of target paths; therefore, <a>"path_hash_prefixes"</a> is
     the union over each prefix of its set of target paths.  The target paths

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -244,7 +244,8 @@ The following are the high-level steps of using the framework from the
 viewpoint of a software update system using the framework.  This is an
 error-free case.
 
-  Polling:
+  : Polling
+  ::
       Periodically, the software update system using the framework
       instructs the framework to check each repository for updates.  If
       the framework reports to the application code that there are
@@ -253,7 +254,8 @@ error-free case.
       trusted (referenced by properly signed and timely metadata) are
       made available by the framework.
 
-  Fetching:
+  : Fetching
+  ::
       For each file that the application wants, it asks the framework to
       download the file.  The framework downloads the file and performs
       security checks to ensure that the downloaded file is exactly what
@@ -430,32 +432,32 @@ metaformat, for example JSON metadata files would have an EXT of json.
 The following are the metadata files of top-level roles relative
 to the base URL of metadata available from a given repository mirror.
 
-  /root.EXT
-
+  : /root.EXT
+  ::
     Signed by the root keys; specifies trusted keys for the other
     top-level roles.
 
-  /snapshot.EXT
-
+  : /snapshot.EXT
+  ::
     Signed by the snapshot role's keys.  Lists the version numbers of all
     target metadata files: the top-level targets.EXT and all delegated
     roles.
 
-  /targets.EXT
-
+  : /targets.EXT
+  ::
     Signed by the target role's keys.  Lists hashes and sizes of target
     files. Specifies delegation information and trusted keys for delegated
     target roles.
 
-  /timestamp.EXT
-
+  : /timestamp.EXT
+  ::
     Signed by the timestamp role's keys.  Lists hash(es), size, and version
     number of the snapshot file.  This is the first and potentially only
     file that needs to be downloaded when clients poll for the existence
     of updates.
 
-  /mirrors.EXT (optional)
-
+  : /mirrors.EXT (optional)
+  ::
     Signed by the mirrors role's keys.  Lists information about available
     mirrors and the content available from each mirror.
 
@@ -468,16 +470,16 @@ base URL of metadata available from a given repository mirror.
 
 A delegated role file is located at:
 
-  /DELEGATED_ROLE.EXT
+  : /DELEGATED_ROLE.EXT
+  ::
+    Where DELEGATED_ROLE is the name of the delegated role that has been
+    specified in targets.EXT.  If this role further delegates trust to a role
+    named ANOTHER_ROLE, that role's signed metadata file is made available at:
 
-where DELEGATED_ROLE is the name of the delegated role that has been
-specified in targets.EXT.  If this role further delegates trust to a role
-named ANOTHER_ROLE, that role's signed metadata file is made available at:
-
-  /ANOTHER_ROLE.EXT
-
-Delegated target roles are authorized by the keys listed in the directly
-delegating target role.
+  : /ANOTHER_ROLE.EXT
+  ::
+    Delegated target roles are authorized by the keys listed in the directly
+    delegating target role.
 
 # Document formats # {#document-formats}
 
@@ -503,94 +505,140 @@ object, we use the "canonical JSON" subdialect as described at
 
 All signed metadata objects have the format:
 
-    { "signed" : ROLE,
-      "signatures" : [
-        { "keyid" : KEYID,
-          "sig" : SIGNATURE }
-        , ... ]
-    }
+<pre highlight="json">
+{
+  "signed" : <a for="role">ROLE</a>,
+  "signatures" : [
+    { "keyid" : <a for="role">KEYID</a>,
+      "sig" : <a>SIGNATURE</a> }
+      , ... ]
+}
+</pre>
 
 where:
 
-      ROLE is a dictionary whose "_type" field describes the role type.
+      : <dfn for="role">ROLE</dfn>
+      ::
+        a dictionary whose "_type" field describes the role type.
 
-      KEYID is the identifier of the key signing the ROLE dictionary.
+      : <dfn for="role">KEYID</dfn>
+      ::
+        the identifier of the key signing the ROLE dictionary.
 
-      SIGNATURE is a hex-encoded signature of the canonical form of
-      the metadata for ROLE.
+      : <dfn>SIGNATURE</dfn>
+      ::
+        a hex-encoded signature of the canonical form of the metadata for ROLE.
 
 
 All keys have the format:
 
-    { "keytype" : KEYTYPE,
-      "scheme" : SCHEME,
-      "keyval" : KEYVAL
-    }
+<pre highlight="json">
+{
+  "keytype" : <a>KEYTYPE</a>,
+  "scheme" : <a>SCHEME</a>,
+  "keyval" : <a>KEYVAL</a>
+}
+</pre>
 
 where:
 
-      KEYTYPE is a string denoting a public key signature system, such
-      as RSA or ECDSA.
+      : <dfn>KEYTYPE</dfn>
+      ::
+        a string denoting a public key signature system, such as <a
+        for="keytype">"rsa"</a>, <a for="keytype">"ed25519"</a>, and <a
+        for="keytype">"ecdsa-sha2-nistp256"</a>.
 
-      SCHEME is a string denoting a corresponding signature scheme.  For
-      example: "rsassa-pss-sha256" and "ecdsa-sha2-nistp256".
+      : <dfn>SCHEME</dfn>
+      ::
+        a string denoting a corresponding signature scheme.  For example: <a
+        for="scheme">"rsassa-pss-sha256"</a>, <a for="scheme">"ed25519"</a> <a
+        for="scheme">"ecdsa-sha2-nistp256"</a>.
 
-      KEYVAL is a dictionary containing the public portion of the key.
+      : <dfn>KEYVAL</dfn>
+      ::
+        a dictionary containing the public portion of the key.
 
 The reference implementation defines three signature schemes, although TUF
 is not restricted to any particular signature scheme, key type, or
 cryptographic library:
 
-    "rsassa-pss-sha256" : RSA Probabilistic signature scheme with appendix.
-    The underlying hash function is SHA256.
-    https://tools.ietf.org/html/rfc3447#page-29
+  : <dfn for="scheme">"rsassa-pss-sha256"</dfn>
+  ::
+    RSA Probabilistic signature scheme with appendix. The underlying hash
+    function is SHA256. https://tools.ietf.org/html/rfc3447#page-29
 
-    "ed25519" : Elliptic curve digital signature algorithm based on Twisted
-    Edwards curves.
+  : <dfn for="scheme">"ed25519"</dfn>
+  ::
+    Elliptic curve digital signature algorithm based on Twisted Edwards curves.
     https://ed25519.cr.yp.to/
 
-    "ecdsa-sha2-nistp256" : Elliptic Curve Digital Signature Algorithm
-      with NIST P-256 curve signing and SHA-256 hashing.
-      https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+  : <dfn for="scheme">"ecdsa-sha2-nistp256"</dfn>
+  ::
+    Elliptic Curve Digital Signature Algorithm with NIST P-256 curve signing
+    and SHA-256 hashing.
+    https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
 
-We define three keytypes below: "rsa", "ed25519", and "ecdsa", but adopters
+We define three keytypes below: <a for="keytype">"rsa"</a>, <a
+for="keytype">"ed25519"</a>, and <a for="keytype">"ecdsa-sha2-nistp256"</a>, but adopters
 can define and use any particular keytype, signing scheme, and cryptographic
 library.
 
-The "rsa" format is:
+The <dfn for="keytype">"rsa"</dfn> format is:
 
-    { "keytype" : "rsa",
-      "scheme" : "rsassa-pss-sha256",
-      "keyval" : {"public" : PUBLIC}
-    }
-
-where PUBLIC is in PEM format and a string.  All RSA keys MUST be at least
-2048 bits.
-
-The "ed25519" format is:
-
-    { "keytype" : "ed25519",
-      "scheme" : "ed25519",
-      "keyval" : {"public" : PUBLIC}
-    }
+<pre highlight="json">
+{
+  "keytype" : "rsa",
+  "scheme" : <a for="scheme">"rsassa-pss-sha256"</a>,
+  "keyval" : {
+    "public" : <a for="keyval-rsa">PUBLIC</a>
+  }
+}
+</pre>
 
 where:
 
-      PUBLIC is a 64-byte hex encoded string.
+  : <dfn for="keyval-rsa">PUBLIC</dfn>
+  ::
+    PEM format and a string.  All RSA keys MUST be at least 2048 bits.
 
-The "ecdsa" format is:
+The <dfn for="keytype">"ed25519"</dfn> format is:
 
-    { "keytype" : "ecdsa-sha2-nistp256",
-      "scheme" : "ecdsa-sha2-nistp256",
-      "keyval" : {"public" : PUBLIC}
-    }
+<pre highlight="json">
+{
+  "keytype" : "ed25519",
+  "scheme" : <a for="scheme">"ed25519"</a>,
+  "keyval" : {
+    "public" : <a for="keyval-ed25519">PUBLIC</a>
+  }
+}
+</pre>
 
 where:
 
-    PUBLIC is in PEM format and a string.
+  : <dfn for="keyval-ed25519">PUBLIC</dfn>
+  ::
+    64-byte hex encoded string.
 
-The KEYID of a key is the hexdigest of the SHA-256 hash of the
-canonical form of the key.
+The <dfn for="keytype">"ecdsa-sha2-nistp256"</dfn> format is:
+
+<pre highlight="json">
+{
+  "keytype" : "ecdsa-sha2-nistp256",
+  "scheme" : <a for="scheme">"ecdsa-sha2-nistp256"</a>,
+  "keyval" : {
+    "public" : <a for="keyval-ecdsa">PUBLIC</a>
+  }
+}
+</pre>
+
+where:
+
+  : <dfn for="keyval-ecdsa">PUBLIC</dfn>
+  ::
+    PEM format and a string.
+
+The <a for="role">KEYID</a> of a key is the hexdigest of the SHA-256 hash of
+the canonical form of the key.
 
 Metadata date-time data follows the ISO 8601 standard.  The expected format
 of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is
@@ -600,326 +648,415 @@ zero UTC offset.  An example date-time string is "1985-10-21T01:21:00Z".
 
 ## File formats: root.json ## {#file-formats-root}
 
-The root.json file is signed by the root role's keys.  It indicates
+The <dfn>root.json</dfn> file is signed by the root role's keys.  It indicates
 which keys are authorized for all top-level roles, including the root
 role itself.  Revocation and replacement of top-level role keys, including
 for the root role, is done by changing the keys listed for the roles in
 this file.
 
-The "signed" portion of root.json is as follows:
+The "signed" portion of <a>root.json</a> is as follows:
 
-    { "_type" : "root",
-      "spec_version" : SPEC_VERSION,
-      "consistent_snapshot": CONSISTENT_SNAPSHOT,
-      "version" : VERSION,
-      "expires" : EXPIRES,
-      "keys" : {
-          KEYID : KEY
-          , ... },
-      "roles" : {
-          ROLE : {
-            "keyids" : [ KEYID, ... ] ,
-            "threshold" : THRESHOLD }
-          , ... }
-    }
-
-SPEC_VERSION is a string that contains the version number of the TUF
-specification. Its format follows the [Semantic Versioning 2.0.0
-(semver)](https://semver.org/spec/v2.0.0.html) specification. Metadata is
-written according to version "spec_version" of the specification, and
-clients MUST verify that "spec_version" matches the expected version number.
-Adopters are free to determine what is considered a match (e.g., the version
-number exactly, or perhaps only the major version number (major.minor.fix).
-
-CONSISTENT_SNAPSHOT is a boolean indicating whether the repository supports
-consistent snapshots.  Section 7 goes into more detail on the consequences
-of enabling this setting on a repository.
-
-VERSION is an integer that is greater than 0.  Clients MUST NOT replace a
-metadata file with a version number less than the one currently trusted.
-
-EXPIRES determines when metadata should be considered expired and no longer
-trusted by clients.  Clients MUST NOT trust an expired file.
-
-A ROLE is one of "root", "snapshot", "targets", "timestamp", or "mirrors".
-A role for each of "root", "snapshot", "timestamp", and "targets" MUST be
-specified in the key list. The role of "mirror" is OPTIONAL.  If not
-specified, the mirror list will not need to be signed if mirror lists are
-being used.
-
-The KEYID MUST be correct for the specified KEY.  Clients MUST calculate
-each KEYID to verify this is correct for the associated key.  Clients MUST
-ensure that for any KEYID represented in this key list and in other files,
-only one unique key has that KEYID.
-
-The THRESHOLD for a role is an integer of the number of keys of that role
-whose signatures are required in order to consider a file as being properly
-signed by that role.
-
-A root.json example file:
-
-    {
-    "signatures": [
-    {
-      "keyid": "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4",
-      "sig": "a312b9c3cb4a1b693e8ebac5ee1ca9cc01f2661c14391917dcb111517f72370809
-              f32c890c6b801e30158ac4efe0d4d87317223077784c7a378834249d048306"
-    }
-    ],
-    "signed": {
-    "_type": "root",
-    "spec_version": "1.0.0",
-    "consistent_snapshot": false,
-    "expires": "2030-01-01T00:00:00Z",
-    "keys": {
-      "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3": {
-      "keytype": "ed25519",
-      "scheme": "ed25519",
-      "keyval": {
-        "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"
-      }
+<pre highlight="json">
+{
+  "_type" : "root",
+  "spec_version" : <a>SPEC_VERSION</a>,
+  "consistent_snapshot": <a>CONSISTENT_SNAPSHOT</a>,
+  "version" : <a for="role">VERSION</a>,
+  "expires" : <a>EXPIRES</a>,
+  "keys" : {
+    <a for="root">KEYID</a> : KEY,
+    ...
+  },
+  "roles" : {
+    <a for="root">ROLE</a> : {
+      "keyids" : [
+        <a for="root">KEYID</a>,
+        ...
+      ] ,
+      "threshold" : <a>THRESHOLD</a>
       },
-      "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164": {
-      "keytype": "ed25519",
-      "scheme": "ed25519",
-      "keyval": {
-        "public": "68ead6e54a43f8f36f9717b10669d1ef0ebb38cee6b05317669341309f1069cb"
-      }
-      },
-      "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4": {
-      "keytype": "ed25519",
-      "scheme": "ed25519",
-      "keyval": {
-        "public": "66dd78c5c2a78abc6fc6b267ff1a8017ba0e8bfc853dd97af351949bba021275"
-      }
-      },
-      "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc": {
-      "keytype": "ed25519",
-      "scheme": "ed25519",
-      "keyval": {
-        "public": "01c61f8dc7d77fcef973f4267927541e355e8ceda757e2c402818dad850f856e"
-      }
-      }
-    },
-    "roles": {
-      "root": {
-      "keyids": [
-        "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4"
-      ],
-      "threshold": 1
-      },
-      "snapshot": {
-      "keyids": [
-        "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc"
-      ],
-      "threshold": 1
-      },
-      "targets": {
-      "keyids": [
-        "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164"
-      ],
-      "threshold": 1
-      },
-      "timestamp": {
-      "keyids": [
-        "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
-      ],
-      "threshold": 1
-      }
-    },
-    "version": 1
-    }
+    ...
   }
+}
+</pre>
+
+where:
+
+  : <dfn>SPEC_VERSION</dfn>
+  ::
+    is a string that contains the version number of the TUF
+    specification. Its format follows the [Semantic Versioning 2.0.0
+    (semver)](https://semver.org/spec/v2.0.0.html) specification. Metadata is
+    written according to version "spec_version" of the specification, and
+    clients MUST verify that "spec_version" matches the expected version number.
+    Adopters are free to determine what is considered a match (e.g., the version
+    number exactly, or perhaps only the major version number (major.minor.fix).
+
+  : <dfn>CONSISTENT_SNAPSHOT</dfn>
+  ::
+    is a boolean indicating whether the repository supports
+    consistent snapshots.  Section 7 goes into more detail on the consequences
+    of enabling this setting on a repository.
+
+  : <dfn for="role">VERSION</dfn>
+  ::
+    is an integer that is greater than 0.  Clients MUST NOT replace a
+    metadata file with a version number less than the one currently trusted.
+
+  : <dfn>EXPIRES</dfn>
+  ::
+    determines when metadata should be considered expired and no longer
+    trusted by clients.  Clients MUST NOT trust an expired file.
+
+  : <dfn for="root">ROLE</dfn>
+  ::
+    is one of "root", "snapshot", "targets", "timestamp", or "mirrors".
+    A role for each of "root", "snapshot", "timestamp", and "targets" MUST be
+    specified in the key list. The role of "mirror" is OPTIONAL.  If not
+    specified, the mirror list will not need to be signed if mirror lists are
+    being used.
+
+  : <dfn for="root">KEYID</dfn>
+  ::
+    The KEYID MUST be correct for the specified KEY.  Clients MUST calculate
+    each KEYID to verify this is correct for the associated key.  Clients MUST
+    ensure that for any KEYID represented in this key list and in other files,
+    only one unique key has that KEYID.
+
+  : <dfn>THRESHOLD</dfn>
+  ::
+    The THRESHOLD for a role is an integer of the number of keys of that role
+    whose signatures are required in order to consider a file as being properly
+    signed by that role.
+
+<div class='example' id='example-root.json'>
+A <a>root.json</a> example file:
+
+<pre highlight="json">
+{
+  "signatures": [
+  {
+    "keyid": "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4",
+    "sig": "a312b9c3cb4a1b693e8ebac5ee1ca9cc01f2661c14391917dcb111517f72370809
+            f32c890c6b801e30158ac4efe0d4d87317223077784c7a378834249d048306"
+  }
+  ],
+  "signed": {
+  "_type": "root",
+  "spec_version": "1.0.0",
+  "consistent_snapshot": false,
+  "expires": "2030-01-01T00:00:00Z",
+  "keys": {
+    "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3": {
+    "keytype": "ed25519",
+    "scheme": "ed25519",
+    "keyval": {
+      "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"
+    }
+    },
+    "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164": {
+    "keytype": "ed25519",
+    "scheme": "ed25519",
+    "keyval": {
+      "public": "68ead6e54a43f8f36f9717b10669d1ef0ebb38cee6b05317669341309f1069cb"
+    }
+    },
+    "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4": {
+    "keytype": "ed25519",
+    "scheme": "ed25519",
+    "keyval": {
+      "public": "66dd78c5c2a78abc6fc6b267ff1a8017ba0e8bfc853dd97af351949bba021275"
+    }
+    },
+    "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc": {
+    "keytype": "ed25519",
+    "scheme": "ed25519",
+    "keyval": {
+      "public": "01c61f8dc7d77fcef973f4267927541e355e8ceda757e2c402818dad850f856e"
+    }
+    }
+  },
+  "roles": {
+    "root": {
+    "keyids": [
+      "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4"
+    ],
+    "threshold": 1
+    },
+    "snapshot": {
+    "keyids": [
+      "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc"
+    ],
+    "threshold": 1
+    },
+    "targets": {
+    "keyids": [
+      "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164"
+    ],
+    "threshold": 1
+    },
+    "timestamp": {
+    "keyids": [
+      "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
+    ],
+    "threshold": 1
+    }
+  },
+  "version": 1
+  }
+}
+</pre>
+</div>
 
 ## File formats: snapshot.json ## {#file-formats-snapshot}
 
-The snapshot.json file is signed by the snapshot role. It MUST list the
+The <dfn>snapshot.json</dfn> file is signed by the snapshot role. It MUST list the
 version numbers of the top-level targets metadata and all delegated targets
 metadata. It MAY also list their lengths and file hashes.
 
-The "signed" portion of snapshot.json is as follows:
+The "signed" portion of <a>snapshot.json</a> is as follows:
 
-    { "_type" : "snapshot",
-      "spec_version" : SPEC_VERSION,
-      "version" : VERSION,
-      "expires" : EXPIRES,
-      "meta" : METAFILES
+<pre highlight="json">
+{
+  "_type" : "snapshot",
+  "spec_version" : <a>SPEC_VERSION</a>,
+  "version" : <a for="role">VERSION</a>,
+  "expires" : <a>EXPIRES</a>,
+  "meta" : <a>METAFILES</a>
+}
+</pre>
+
+<a>SPEC_VERSION</a>, <a for="role">VERSION</a> and <a>EXPIRES</a> are the same
+as is described for the <a>root.json</a> file.
+
+<dfn>METAFILES</dfn> is an object whose format is the following:
+
+<pre highlight="json">
+{
+  <a>METAPATH</a> : {
+      "version" : <a for="metapath">VERSION</a>,
+      ("length" : <a for="metapath">LENGTH</a>,)
+      ("hashes" : <a for="metapath">HASHES</a>)
+  },
+  ...
+}
+</pre>
+
+where:
+
+  : <dfn>METAPATH</dfn>
+  ::
+    the file path of the metadata on the repository relative to the
+    metadata base URL. For snapshot.json, these are top-level targets metadata
+    and delegated targets metadata.
+
+  : <dfn for="metapath">VERSION</dfn>
+  ::
+    the integer version number as shown in the metadata file at <a>METAPATH</a>.
+
+  : <dfn for="metapath">LENGTH</dfn>
+  ::
+    the integer length in bytes of the metadata file at <a>METAPATH</a>. It
+    is OPTIONAL and can be omitted to reduce the snapshot metadata file size. In
+    that case the client MUST use a custom download limit for the listed
+    metadata.
+
+  : <dfn for="metapath">HASHES</dfn>
+  ::
+    a dictionary that specifies one or more hashes of the metadata
+    file at <a>METAPATH</a>, including their cryptographic hash function. For
+    example: { "sha256": HASH, ... }. HASHES is OPTIONAL and can be omitted to
+    reduce the snapshot metadata file size.  In that case the repository MUST
+    guarantee that <a for="metapath">VERSION</a> alone unambiguously identifies
+    the metadata at <a>METAPATH</a>.
+
+<div class="example" id="example-snapshot.json">
+A <a>snapshot.json</a> example file:
+
+<pre highlight="json">
+{
+  "signatures": [
+    {
+    "keyid": "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc",
+    "sig": "f7f03b13e3f4a78a23561419fc0dd741a637e49ee671251be9f8f3fceedfc112e4
+            4ee3aaff2278fad9164ab039118d4dc53f22f94900dae9a147aa4d35dcfc0f"
     }
-
-SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
-
-METAFILES is an object whose format is the following:
-
-    { METAPATH : {
-          "version" : VERSION,
-          ("length" : LENGTH,)
-          ("hashes" : HASHES) }
-      , ...
-    }
-
-METAPATH is the file path of the metadata on the repository relative to the
-metadata base URL. For snapshot.json, these are top-level targets metadata
-and delegated targets metadata.
-
-VERSION is the integer version number as shown in the metadata file at
-METAPATH.
-
-LENGTH is the integer length in bytes of the metadata file at METAPATH. It
-is OPTIONAL and can be omitted to reduce the snapshot metadata file size. In
-that case the client MUST use a custom download limit for the listed
-metadata.
-
-HASHES is a dictionary that specifies one or more hashes of the metadata
-file at METAPATH, including their cryptographic hash function. For example:
-{ "sha256": HASH, ... }. HASHES is OPTIONAL and can be omitted to reduce
-the snapshot metadata file size.  In that case the repository MUST guarantee
-that VERSION alone unambiguously identifies the metadata at METAPATH.
-
-A snapshot.json example file:
-
-    { "signatures": [
-      {
-      "keyid": "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc",
-      "sig": "f7f03b13e3f4a78a23561419fc0dd741a637e49ee671251be9f8f3fceedfc112e4
-              4ee3aaff2278fad9164ab039118d4dc53f22f94900dae9a147aa4d35dcfc0f"
-      }
-    ],
-    "signed": {
-      "_type": "snapshot",
-      "spec_version": "1.0.0",
-      "expires": "2030-01-01T00:00:00Z",
-      "meta": {
-      "targets.json": {
-        "version": 1
-      },
-      "project1.json": {
-        "version": 1,
-        "hashes": {
-        "sha256": "f592d072e1193688a686267e8e10d7257b4ebfcf28133350dae88362d82a0c8a"
-        }
-      },
-      "project2.json": {
-        "version": 1,
-        "length": 604,
-        "hashes": {
-        "sha256": "1f812e378264c3085bb69ec5f6663ed21e5882bbece3c3f8a0e8479f205ffb91"
-        }
-      }
-      },
+  ],
+  "signed": {
+    "_type": "snapshot",
+    "spec_version": "1.0.0",
+    "expires": "2030-01-01T00:00:00Z",
+    "meta": {
+    "targets.json": {
       "version": 1
+    },
+    "project1.json": {
+      "version": 1,
+      "hashes": {
+      "sha256": "f592d072e1193688a686267e8e10d7257b4ebfcf28133350dae88362d82a0c8a"
+      }
+    },
+    "project2.json": {
+      "version": 1,
+      "length": 604,
+      "hashes": {
+      "sha256": "1f812e378264c3085bb69ec5f6663ed21e5882bbece3c3f8a0e8479f205ffb91"
+      }
     }
-    }
+    },
+    "version": 1
+  }
+}
+</pre>
+</div>
 
 ## File formats: targets.json and delegated target roles ## {#file-formats-targets}
 
-The "signed" portion of targets.json is as follows:
+The "signed" portion of <dfn>targets.json</dfn> is as follows:
 
-    { "_type" : "targets",
-      "spec_version" : SPEC_VERSION,
-      "version" : VERSION,
-      "expires" : EXPIRES,
-      "targets" : TARGETS,
-      ("delegations" : DELEGATIONS)
-    }
+<pre highlight="json">
+{
+  "_type" : "targets",
+  "spec_version" : <a>SPEC_VERSION</a>,
+  "version" : <a for="role">VERSION</a>,
+  "expires" : <a>EXPIRES</a>,
+  "targets" : <a>TARGETS</a>,
+  ("delegations" : <a>DELEGATIONS</a>)
+}
+</pre>
 
-SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
+<a>SPEC_VERSION</a>, <a for="role">VERSION</a> and <a>EXPIRES</a> are the same
+as is described for the <a>root.json</a> file.
 
-TARGETS is an object whose format is the following:
+<dfn for="targets-obj">TARGETS</dfn> is an object whose format is the following:
 
-    { TARGETPATH : {
-          "length" : LENGTH,
-          "hashes" : HASHES,
-          ("custom" : CUSTOM) }
-      , ...
-    }
+<pre highlight="json">
+{
+  <a>TARGETPATH</a> : {
+      "length" : <a for="targets-obj">LENGTH</a>,
+      "hashes" : <a for="targets-obj">HASHES</a>,
+      ("custom" : <a>CUSTOM</a>) }
+  , ...
+}
+</pre>
 
-Each key of the TARGETS object is a TARGETPATH.  A TARGETPATH is a path to
-a file that is relative to a mirror's base URL of targets. To avoid
-surprising behavior when resolving paths, it is RECOMMENDED that a
-TARGETPATH uses the forward slash (/) as directory separator and does not
-start with a directory separator. The recommendation for TARGETPATH aligns
-with the ["path-relative-URL string"
-definition](https://url.spec.whatwg.org/#path-relative-url-string) in the
-WHATWG URL specification.
+where:
 
-It is allowed to have a TARGETS object with no TARGETPATH elements.  This
-can be used to indicate that no target files are available.
+  : <a for="targets-obj">TARGETS</a>
+  ::
+    Each key of the TARGETS object is a TARGETPATH.
 
-LENGTH is the integer length in bytes of the target file at TARGETPATH.
+  : <dfn>TARGETPATH</dfn>
+  ::
+    a path to a file that is relative to a mirror's base URL of targets.
+    To avoid surprising behavior when resolving paths, it is RECOMMENDED that
+    a TARGETPATH uses the forward slash (/) as directory separator and does not
+    start with a directory separator. The recommendation for TARGETPATH aligns
+    with the ["path-relative-URL string"
+    definition](https://url.spec.whatwg.org/#path-relative-url-string) in the
+    WHATWG URL specification.
 
-HASHES is a dictionary that specifies one or more hashes, including the
-cryptographic hash function.  For example: { "sha256": HASH, ... }. HASH is
-the hexdigest of the cryptographic function computed on the target file.
+    It is allowed to have a <a>TARGETS</a> object with no TARGETPATH elements.  This
+    can be used to indicate that no target files are available.
 
-If defined, the elements and values of the CUSTOM object will be made
-available to the client application.  The format of the CUSTOM object is
-opaque to the framework, which only needs to know that the "custom"
-attribute maps to an object.  The CUSTOM object may include version
-numbers, dependencies, requirements, or any other data that the application
-wants to include to describe the file at TARGETPATH.  The application may
-use this information to guide download decisions.
+  : <dfn for="targets-obj">LENGTH</dfn>
+  ::
+    the integer length in bytes of the target file at <a>TARGETPATH</a>.
 
-DELEGATIONS is an object whose format is the following:
+  : <dfn for="targets-obj">HASHES</dfn>
+  ::
+    a dictionary that specifies one or more hashes, including the
+    cryptographic hash function.  For example: { "sha256": HASH, ... }. HASH is
+    the hexdigest of the cryptographic function computed on the target file.
 
-    { "keys" : {
-          KEYID : KEY,
-          ... },
-      "roles" : [{
-          "name": ROLENAME,
-          "keyids" : [ KEYID, ... ] ,
-          "threshold" : THRESHOLD,
-          ("path_hash_prefixes" : [ HEX_DIGEST, ... ] |
-          "paths" : [ PATHPATTERN, ... ]),
-          "terminating": TERMINATING,
-      }, ... ]
-    }
+  : <dfn>CUSTOM</a>
+  ::
+    If defined, the elements and values of the CUSTOM object will be made
+    available to the client application.  The format of the CUSTOM object is
+    opaque to the framework, which only needs to know that the "custom"
+    attribute maps to an object.  The CUSTOM object may include version
+    numbers, dependencies, requirements, or any other data that the application
+    wants to include to describe the file at <a>TARGETPATH</a>.  The
+    application may use this information to guide download decisions.
 
-"keys" lists the public keys to verify signatures of delegated targets roles.
-Revocation and replacement of delegated targets roles keys is done by
-changing the keys in this field in the delegating role's metadata.
+<dfn>DELEGATIONS</dfn> is an object whose format is the following:
 
-ROLENAME is the name of the delegated role.  For example,
-"projects".
+<pre highlight="json">
+{
+  "keys" : {
+      KEYID : KEY,
+      ...
+  },
+  "roles" : [
+    {
+      "name": <a>ROLENAME</a>,
+      "keyids" : [ KEYID, ... ] ,
+      "threshold" : <a>THRESHOLD</a>,
+      ("path_hash_prefixes" : [ HEX_DIGEST, ... ] |
+      "paths" : [ PATHPATTERN, ... ]),
+      "terminating": <a>TERMINATING</a>,
+    },
+    ...
+  ]
+}
+</pre>
 
-TERMINATING is a boolean indicating whether subsequent delegations should be
-considered.
+where:
 
-As explained in the [Diplomat
-paper](https://github.com/theupdateframework/tuf/blob/develop/docs/papers/protect-community-repositories-nsdi2016.pdf),
-terminating delegations instruct the client not to consider future trust
-statements that match the delegation's pattern, which stops the delegation
-processing once this delegation (and its descendants) have been processed.
-A terminating delegation for a package causes any further statements about a
-package that are not made by the delegated party or its descendants to be
-ignored.
+  : "keys"
+  ::
+    lists the public keys to verify signatures of delegated targets roles.
+    Revocation and replacement of delegated targets roles keys is done by
+    changing the keys in this field in the delegating role's metadata.
+
+  : <dfn>ROLENAME</dfn>
+  ::
+    the name of the delegated role.  For example, "projects".
+
+  : <dfn>TERMINATING</dfn>
+  ::
+    a boolean indicating whether subsequent delegations should be considered.
+
+    As explained in the [Diplomat
+    paper](https://github.com/theupdateframework/tuf/blob/develop/docs/papers/protect-community-repositories-nsdi2016.pdf),
+    terminating delegations instruct the client not to consider future trust
+    statements that match the delegation's pattern, which stops the delegation
+    processing once this delegation (and its descendants) have been processed.
+    A terminating delegation for a package causes any further statements about a
+    package that are not made by the delegated party or its descendants to be
+    ignored.
 
 In order to discuss target paths, a role MUST specify only one of the
 "path_hash_prefixes" or "paths" attributes, each of which we discuss next.
 
-The "path_hash_prefixes" list is used to succinctly describe a set of target
-paths. Specifically, each HEX_DIGEST in "path_hash_prefixes" describes a set
-of target paths; therefore, "path_hash_prefixes" is the union over each
-prefix of its set of target paths. The target paths must meet this
-condition: each target path, when hashed with the SHA-256 hash function to
-produce a 64-byte hexadecimal digest (HEX_DIGEST), must share the same
-prefix as one of the prefixes in "path_hash_prefixes". This is useful to
-split a large number of targets into separate bins identified by consistent
-hashing.
+  : "path_hash_prefixes"
+  ::
+    The "path_hash_prefixes" list is used to succinctly describe a set of target
+    paths. Specifically, each HEX_DIGEST in "path_hash_prefixes" describes a set
+    of target paths; therefore, "path_hash_prefixes" is the union over each
+    prefix of its set of target paths. The target paths must meet this
+    condition: each target path, when hashed with the SHA-256 hash function to
+    produce a 64-byte hexadecimal digest (HEX_DIGEST), must share the same
+    prefix as one of the prefixes in "path_hash_prefixes". This is useful to
+    split a large number of targets into separate bins identified by consistent
+    hashing.
 
-The "paths" list describes paths that the role is trusted to provide.
-Clients MUST check that a target is in one of the trusted paths of all roles
-in a delegation chain, not just in a trusted path of the role that describes
-the target file.  PATHPATTERN can include shell-style wildcards and supports
-the Unix filename pattern matching convention.  Its format may either
-indicate a path to a single file, or to multiple paths with the use of
-shell-style wildcards.  For example, the path pattern "targets/*.tgz" would
-match file paths "targets/foo.tgz" and "targets/bar.tgz", but not
-"targets/foo.txt".  Likewise, path pattern "foo-version-?.tgz" matches
-"foo-version-2.tgz" and "foo-version-a.tgz", but not "foo-version-alpha.tgz".
-To avoid surprising behavior when matching targets with PATHPATTERN, it is
-RECOMMENDED that PATHPATTERN uses the forward slash (/) as directory
-separator and does not start with a directory separator, akin to
-TARGETSPATH.
+  : "paths"
+  ::
+    The "paths" list describes paths that the role is trusted to provide.
+    Clients MUST check that a target is in one of the trusted paths of all roles
+    in a delegation chain, not just in a trusted path of the role that describes
+    the target file.  PATHPATTERN can include shell-style wildcards and supports
+    the Unix filename pattern matching convention.  Its format may either
+    indicate a path to a single file, or to multiple paths with the use of
+    shell-style wildcards.  For example, the path pattern "targets/*.tgz" would
+    match file paths "targets/foo.tgz" and "targets/bar.tgz", but not
+    "targets/foo.txt".  Likewise, path pattern "foo-version-?.tgz" matches
+    "foo-version-2.tgz" and "foo-version-a.tgz", but not "foo-version-alpha.tgz".
+    To avoid surprising behavior when matching targets with PATHPATTERN, it is
+    RECOMMENDED that PATHPATTERN uses the forward slash (/) as directory
+    separator and does not start with a directory separator, akin to
+    TARGETSPATH.
 
 
 Prioritized delegations allow clients to resolve conflicts between delegated
@@ -934,66 +1071,70 @@ delegations, the "roles" key in the DELEGATIONS object above points to an array
 of delegated roles, rather than to a hash table.
 
 The metadata files for delegated target roles has the same format as the
-top-level targets.json metadata file.
+top-level <a>targets.json</a> metadata file.
 
-A targets.json example file:
+<div class="example" id="example-targets.json">
+A <a>targets.json</a> example file:
 
-    {
+<pre highlight="json">
+  {
     "signatures": [
-    {
-      "keyid": "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164",
-      "sig": "e9fd40008fba263758a3ff1dc59f93e42a4910a282749af915fbbea1401178e5a0
-              12090c228f06db1deb75ad8ddd7e40635ac51d4b04301fce0fd720074e0209"
-    }
+      {
+        "keyid": "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164",
+        "sig": "e9fd40008fba263758a3ff1dc59f93e42a4910a282749af915fbbea1401178e5a0
+                12090c228f06db1deb75ad8ddd7e40635ac51d4b04301fce0fd720074e0209"
+      }
     ],
     "signed": {
-    "_type": "targets",
-    "spec_version": "1.0.0",
-    "delegations": {
-      "keys": {
-      "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6": {
-        "keytype": "ed25519",
-        "scheme": "ed25519",
-        "keyval": {
-        "public": "b6e40fb71a6041212a3d84331336ecaa1f48a0c523f80ccc762a034c727606fa"
+      "_type": "targets",
+      "spec_version": "1.0.0",
+      "delegations": {
+        "keys": {
+        "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6": {
+          "keytype": "ed25519",
+          "scheme": "ed25519",
+          "keyval": {
+          "public": "b6e40fb71a6041212a3d84331336ecaa1f48a0c523f80ccc762a034c727606fa"
+          }
         }
-      }
+        },
+        "roles": [
+        {
+          "keyids": [
+          "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6"
+          ],
+          "name": "project",
+          "paths": [
+          "project/file3.txt"
+          ],
+          "threshold": 1
+        }
+        ]
       },
-      "roles": [
-      {
-        "keyids": [
-        "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6"
-        ],
-        "name": "project",
-        "paths": [
-        "project/file3.txt"
-        ],
-        "threshold": 1
-      }
-      ]
-    },
-    "expires": "2030-01-01T00:00:00Z",
-    "targets": {
-      "file1.txt": {
-      "hashes": {
-        "sha256": "65b8c67f51c993d898250f40aa57a317d854900b3a04895464313e48785440da"
+      "expires": "2030-01-01T00:00:00Z",
+      "targets": {
+        "file1.txt": {
+        "hashes": {
+          "sha256": "65b8c67f51c993d898250f40aa57a317d854900b3a04895464313e48785440da"
+        },
+        "length": 31
+        },
+        "dir/file2.txt": {
+        "hashes": {
+          "sha256": "452ce8308500d83ef44248d8e6062359211992fd837ea9e370e561efb1a4ca99"
+        },
+        "length": 39
+        }
       },
-      "length": 31
-      },
-      "dir/file2.txt": {
-      "hashes": {
-        "sha256": "452ce8308500d83ef44248d8e6062359211992fd837ea9e370e561efb1a4ca99"
-      },
-      "length": 39
-      }
-    },
-    "version": 1
+      "version": 1
     }
-    }
+  }
+</pre>
+</div>
 
 ## File formats: timestamp.json ## {#file-formats-timestamp}
 
-The timestamp file is signed by a timestamp key.  It indicates the latest
+The <dfn>timestamp.json</dfn> file is signed by the timestamp role.  It indicates the latest
 version of the snapshot metadata and is frequently re-signed to limit the
 amount of time a client can be kept unaware of interference with obtaining
 updates.
@@ -1001,74 +1142,87 @@ updates.
 Timestamp files will potentially be downloaded very frequently.  Unnecessary
 information in them will be avoided.
 
-The "signed" portion of timestamp.json is as follows:
+The "signed" portion of <a>timestamp.json</a> is as follows:
 
-    { "_type" : "timestamp",
-      "spec_version" : SPEC_VERSION,
-      "version" : VERSION,
-      "expires" : EXPIRES,
-      "meta" : METAFILES
-    }
+<pre highlight="json">
+{
+  "_type" : "timestamp",
+  "spec_version" : <a>SPEC_VERSION</a>,
+  "version" : <a for="role">VERSION</a>,
+  "expires" : <a>EXPIRES</a>,
+  "meta" : <a>METAFILES</a>
+}
+</pre>
 
-SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
+<a>SPEC_VERSION</a>, <a for="role">VERSION</a> and <a>EXPIRES</a> are the same as is described for the root.json file.
 
-METAFILES is the same as described for the snapshot.json file.  In the case
+<a>METAFILES</a> is the same as described for the <a>snapshot.json</a> file.  In the case
 of the timestamp.json file, this MUST only include a description of the
-snapshot.json file.
+<a>snapshot.json</a> file.
 
-A signed timestamp.json example file:
-
-    {
-    "signatures": [
-    {
-      "keyid": "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3",
-      "sig": "90d2a06c7a6c2a6a93a9f5771eb2e5ce0c93dd580bebc2080d10894623cfd6eaed
-              f4df84891d5aa37ace3ae3736a698e082e12c300dfe5aee92ea33a8f461f02"
-    }
-    ],
-    "signed": {
-    "_type": "timestamp",
-    "spec_version": "1.0.0",
-    "expires": "2030-01-01T00:00:00Z",
-    "meta": {
-      "snapshot.json": {
-      "hashes": {
-        "sha256": "c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681"
-      },
-      "length": 1007,
-      "version": 1
-      }
+<div class="example" id="example-timestamp.json">
+A signed <a>timestamp.json</a> example file:
+<pre highlight="json">
+{
+  "signatures": [
+  {
+    "keyid": "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3",
+    "sig": "90d2a06c7a6c2a6a93a9f5771eb2e5ce0c93dd580bebc2080d10894623cfd6eaed
+            f4df84891d5aa37ace3ae3736a698e082e12c300dfe5aee92ea33a8f461f02"
+  }
+  ],
+  "signed": {
+  "_type": "timestamp",
+  "spec_version": "1.0.0",
+  "expires": "2030-01-01T00:00:00Z",
+  "meta": {
+    "snapshot.json": {
+    "hashes": {
+      "sha256": "c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681"
     },
+    "length": 1007,
     "version": 1
     }
-    }
+  },
+  "version": 1
+  }
+}
+</pre>
+</div>
 
 ## File formats: mirrors.json ## {#file-formats-mirrors}
 
-The mirrors.json file is signed by the mirrors role.  It indicates which
+The <dfn>mirrors.json</dfn> file is signed by the mirrors role.  It indicates which
 mirrors are active and believed to be mirroring specific parts of the
 repository.
 
-The "signed" portion of mirrors.json is as follows:
+The "signed" portion of <a>mirrors.json</a> is as follows:
 
+<pre highlight="json">
+{
+  "_type" : "mirrors",
+  "spec_version" : <a>SPEC_VERSION</a>,
+  "version" : <a for="role">VERSION</a>,
+  "expires" : <a>EXPIRES</a>,
+  "mirrors" : [
+    { "urlbase" : <a>URLBASE</a>,
+      "metapath" : <a>METAPATH</a>,
+      "targetspath" : TARGETSPATH,
+      "metacontent" : [ PATHPATTERN ... ] ,
+      "targetscontent" : [ PATHPATTERN ... ] ,
+      ("custom" : { ... }) }
+    , ... ]
+}
+</pre>
 
-  { "_type" : "mirrors",
-    "spec_version" : SPEC_VERSION,
-    "version" : VERSION,
-    "expires" : EXPIRES,
-    "mirrors" : [
-      { "urlbase" : URLBASE,
-        "metapath" : METAPATH,
-        "targetspath" : TARGETSPATH,
-        "metacontent" : [ PATHPATTERN ... ] ,
-        "targetscontent" : [ PATHPATTERN ... ] ,
-        ("custom" : { ... }) }
-      , ... ]
-  }
+<a>SPEC_VERSION</a>, <a for="role">VERSION</a> and <a>EXPIRES</a> are the same
+as is described for the <a>root.json</a> file.
 
-URLBASE is the URL of the mirror which METAPATH and TARGETSPATH are relative
-to.  All metadata files will be retrieved from METAPATH and all target files
-will be retrieved from TARGETSPATH.
+  : <dfn>URLBASE</dfn>
+  ::
+    the URL of the mirror which <a>METAPATH</a> and TARGETSPATH are relative
+    to.  All metadata files will be retrieved from <a>METAPATH</a> and all target files
+    will be retrieved from TARGETSPATH.
 
 The lists of PATHPATTERN for "metacontent" and "targetscontent" describe the
 metadata files and target files available from the mirror.
@@ -1353,8 +1507,8 @@ it in the next step.
 
 # 6. Usage # {#usage}
 
-See https://theupdateframework.io/ for discussion of recommended usage
-in various situations.
+See [theupdateframework.io](https://theupdateframework.io/) for discussion of
+recommended usage in various situations.
 
 ## Key management and migration ## {#key-management-and-migration}
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1,4 +1,14 @@
-# <p align="center">The Update Framework Specification
+<pre class=metadata>
+Status: DREAM
+Shortname: tuf
+Abstract: todo
+Group: tuf
+Title: The Update Framework Specification
+Editor: foo
+Indent: 2
+Boilerplate: copyright no
+Markup Shorthands: css no, markdown yes
+</pre>
 
 Last modified: **3 December 2020**
 
@@ -12,1098 +22,1095 @@ or by reporting an issue in the [specification
 repo](https://github.com/theupdateframework/specification/issues).
 
 
-## Table of Contents ##
-- [1. Introduction](#1-introduction)
-- [2. System overview](#2-system-overview)
-- [3. The repository](#3-the-repository)
-- [4. Document formats](#4-document-formats)
-- [5. Detailed workflows](#5-detailed-workflows)
-- [6. Usage](#6-usage)
-- [7. Consistent snapshots](#7-consistent-snapshots)
-- [F. Future directions and open questions](#f-future-directions-and-open-questions)
-
-## **1. Introduction**
-* **1.1. Scope**
-
-   This document describes a framework for securing software update systems.
-
-   The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD,"
-   "SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be
-   interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-
-* **1.2. Motivation**
-
-   Software is commonly updated through software update systems.  These systems
-   can be package managers that are responsible for all of the software that is
-   installed on a system, application updaters that are only responsible for
-   individual installed applications, or software library managers that install
-   software that adds functionality such as plugins or programming language
-   libraries.
-
-   Software update systems all have the common behavior of downloading files
-   that identify whether updates exist and, when updates do exist, downloading
-   the files that are required for the update.  For the implementations
-   concerned with security, various integrity and authenticity checks are
-   performed on downloaded files.
-
-   Software update systems are vulnerable to a variety of known attacks.  This
-   is generally true even for implementations that have tried to be secure.
-
-* **1.3. History and credit**
-
-   Work on TUF began in late 2009.  The core ideas are based off of previous
-   work done by Justin Cappos and Justin Samuel that [identified security flaws
-   in all popular Linux package managers](https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf).
-   More information and current versions of this document can be found at
-   https://theupdateframework.io/
-
-   The [Global Environment for Network Innovations](https://www.geni.net/) (GENI)
-   and the [National Science Foundation](https://www.nsf.gov/) (NSF) have
-   provided support for the development of TUF.
-
-   TUF's reference implementation is based on prior work on
-   [Thandy](https://www.torproject.org/), the application
-   updater for Tor. Its design and this spec
-   also came from ideas jointly developed in discussion with Thandy's authors.
-   The Thandy spec can be found at
-   https://gitweb.torproject.org/thandy.git/tree/specs/thandy-spec.txt
-
-   Whereas Thandy is an application updater for an individual software project,
-   TUF aims to provide a way to secure any software update system. We're very
-   grateful to the Tor Project and the Thandy developers for the early discussion
-   that led to the ideas in Thandy and TUF. Thandy is the hard
-   work of Nick Mathewson, Sebastian Hahn, Roger Dingledine, Martin Peck, and
-   others.
-
- * **1.4. Non-goals**
-
-   We are not creating a universal update system, but rather a simple and
-   flexible way that applications can have high levels of security with their
-   software update systems.  Creating a universal software update system would
-   not be a reasonable goal due to the diversity of application-specific
-   functionality in software update systems and the limited usefulness that
-   such a system would have for securing legacy software update systems.
-
-   We won't be defining package formats or even performing the actual update
-   of application files.  We will provide the simplest mechanism possible that
-   remains easy to use and provides a secure way for applications to obtain and
-   verify files being distributed by trusted parties.
-
-   We are not providing a means to bootstrap security so that arbitrary
-   installation of new software is secure.  In practice this means that people
-   still need to use other means to verify the integrity and authenticity of
-   files they download manually.
-
-   The framework will not have the responsibility of deciding on the correct
-   course of action in all error situations, such as those that can occur when
-   certain attacks are being performed.  Instead, the framework will provide
-   the software update system the relevant information about any errors that
-   require security decisions which are situation-specific.  How those errors
-   are handled is up to the software update system.
-
-* **1.5. Goals**
-
-   We need to provide a framework (a set of libraries, file formats, and
-   utilities) that can be used to secure new and existing software update
-   systems.
-
-   The framework should enable applications to be secure from all known attacks
-   on the software update process.  It is not concerned with exposing
-   information about what software is being updated (and thus what software
-   the client may be running) or the contents of updates.
-
-   The framework should provide means to minimize the impact of key compromise.
-   To do so, it must support roles with multiple keys and threshold/quorum
-   trust (with the exception of minimally trusted roles designed to use a
-   single key).  The compromise of roles using highly vulnerable keys should
-   have minimal impact.  Therefore, online keys (keys which are used in an
-   automated fashion) must not be used for any role that clients ultimately
-   trust for files they may install.
-
-   The framework must be flexible enough to meet the needs of a wide variety of
-   software update systems.
-
-   The framework must be easy to integrate with software update systems.
+# Introduction # {#introduction}
+
+## Scope ## {#scope}
+
+This document describes a framework for securing software update systems.
+
+The keywords "MUST," "MUST NOT," "REQUIRED," "SHALL," "SHALL NOT," "SHOULD,"
+"SHOULD NOT," "RECOMMENDED," "MAY," and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+## Motivation ## {#motivation}
+
+Software is commonly updated through software update systems.  These systems
+can be package managers that are responsible for all of the software that is
+installed on a system, application updaters that are only responsible for
+individual installed applications, or software library managers that install
+software that adds functionality such as plugins or programming language
+libraries.
+
+Software update systems all have the common behavior of downloading files
+that identify whether updates exist and, when updates do exist, downloading
+the files that are required for the update.  For the implementations
+concerned with security, various integrity and authenticity checks are
+performed on downloaded files.
+
+Software update systems are vulnerable to a variety of known attacks.  This
+is generally true even for implementations that have tried to be secure.
+
+## History and credit ## {#history-and-credit}
+
+Work on TUF began in late 2009.  The core ideas are based off of previous
+work done by Justin Cappos and Justin Samuel that [identified security flaws
+in all popular Linux package managers](https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf).
+More information and current versions of this document can be found at
+https://theupdateframework.io/
+
+The [Global Environment for Network Innovations](https://www.geni.net/) (GENI)
+and the [National Science Foundation](https://www.nsf.gov/) (NSF) have
+provided support for the development of TUF.
+
+TUF's reference implementation is based on prior work on
+[Thandy](https://www.torproject.org/), the application
+updater for Tor. Its design and this spec
+also came from ideas jointly developed in discussion with Thandy's authors.
+The Thandy spec can be found at
+https://gitweb.torproject.org/thandy.git/tree/specs/thandy-spec.txt
+
+Whereas Thandy is an application updater for an individual software project,
+TUF aims to provide a way to secure any software update system. We're very
+grateful to the Tor Project and the Thandy developers for the early discussion
+that led to the ideas in Thandy and TUF. Thandy is the hard
+work of Nick Mathewson, Sebastian Hahn, Roger Dingledine, Martin Peck, and
+others.
+
+## Non-goals ## {#non-goals}
+
+We are not creating a universal update system, but rather a simple and
+flexible way that applications can have high levels of security with their
+software update systems.  Creating a universal software update system would
+not be a reasonable goal due to the diversity of application-specific
+functionality in software update systems and the limited usefulness that
+such a system would have for securing legacy software update systems.
+
+We won't be defining package formats or even performing the actual update
+of application files.  We will provide the simplest mechanism possible that
+remains easy to use and provides a secure way for applications to obtain and
+verify files being distributed by trusted parties.
+
+We are not providing a means to bootstrap security so that arbitrary
+installation of new software is secure.  In practice this means that people
+still need to use other means to verify the integrity and authenticity of
+files they download manually.
+
+The framework will not have the responsibility of deciding on the correct
+course of action in all error situations, such as those that can occur when
+certain attacks are being performed.  Instead, the framework will provide
+the software update system the relevant information about any errors that
+require security decisions which are situation-specific.  How those errors
+are handled is up to the software update system.
+
+## Goals ## {#goals}
+
+We need to provide a framework (a set of libraries, file formats, and
+utilities) that can be used to secure new and existing software update
+systems.
+
+The framework should enable applications to be secure from all known attacks
+on the software update process.  It is not concerned with exposing
+information about what software is being updated (and thus what software
+the client may be running) or the contents of updates.
+
+The framework should provide means to minimize the impact of key compromise.
+To do so, it must support roles with multiple keys and threshold/quorum
+trust (with the exception of minimally trusted roles designed to use a
+single key).  The compromise of roles using highly vulnerable keys should
+have minimal impact.  Therefore, online keys (keys which are used in an
+automated fashion) must not be used for any role that clients ultimately
+trust for files they may install.
+
+The framework must be flexible enough to meet the needs of a wide variety of
+software update systems.
 
-   - **1.5.1 Goals for implementation**
+The framework must be easy to integrate with software update systems.
 
-      + The client side of the framework must be straightforward to implement in any
-   programming language and for any platform with the requisite networking and
-   crypto support.
-
-      +  The process by which developers push updates to the repository must be
-   simple.
-
-      + The framework must be secure to use in environments that lack support for
-   SSL (TLS).  This does not exclude the optional use of SSL when available,
-   but the framework will be designed without it.
-
-   - **1.5.2. Goals to protect against specific attacks**
-
-      Note: When saying the framework protects against an attack, it means the
-      attack will be unsuccessful.  It does not mean that a client will always
-      successfully update during an attack.  Fundamentally, an attacker
-      positioned to intercept and modify a client's communication can always
-      perform a denial of service.  Nevertheless, the framework must detect
-      when a client is unable to update.
-
-      + **Arbitrary installation attacks.** An attacker cannot install anything
-      they want on the client system. That is, an attacker cannot provide
-      arbitrary files in response to download requests.
-
-      + **Endless data attacks.**  An attacker cannot respond to client
-      requests with huge amounts of data (extremely large files) that interfere
-      with the client's system.
-
-      + **Extraneous dependencies attacks.**  An attacker cannot cause clients
-      to download or install software dependencies that are not the intended
-      dependencies.
-
-      + **Fast-forward attacks.**  An attacker cannot arbitrarily increase the
-      version numbers of metadata files, listed in the snapshot metadata, well
-      beyond the current value and thus tricking a software update system into
-      thinking any subsequent updates are trying to rollback the package to a
-      previous, out-of-date version.  In some situations, such as those where
-      there is a maximum possible version number, the perpetrator cannot use a
-      number so high that the system would never be able to match it with the
-      one in the snapshot metadata, and thus new updates could never be
-      downloaded.
-
-      + **Indefinite freeze attacks.**  An attacker cannot respond to client
-      requests with the same, outdated metadata without the client being aware
-      of the problem.
-
-      + **Malicious mirrors preventing updates.**  A repository mirror cannot
-      prevent updates from good mirrors.
-
-      + **Mix-and-match attacks.**  An attacker cannot trick clients into using
-      a combination of metadata that never existed together on the repository
-      at the same time.
-
-      + **Rollback attacks.**  An attacker cannot trick clients into installing
-      software that is older than that which the client previously knew to be
-      available.
-
-      + **Vulnerability to key compromises.** An attacker, who is able to
-      compromise a single key or less than a given threshold of keys, cannot
-      compromise clients.  This includes compromising a single online key (such
-      as only being protected by SSL) or a single offline key (such as most
-      software update systems use to sign files).
-
-      + **Wrong software installation.**  An attacker cannot provide a file
-      (trusted or untrusted) that is not the one the client wanted.
-
-   - **1.5.3. Goals for PKIs**
-
-      * Software update systems using the framework's client code interface should
-      never have to directly manage keys.
-
-      * All keys must be easily and safely revocable.  Trusting new keys for a role
-      must be easy.
-
-      * For roles where trust delegation is meaningful, a role should be able to
-      delegate full or limited trust to another role.
-
-      * The root of trust must not rely on external PKI.  That is, no authority will
-      be derived from keys outside of the framework.
-
-    - **1.5.4. TUF Augmentation Proposal support**
-
-      * This version (1.0.0) of the specification adheres to the following TAPS:
-
-        - [TAP 6](https://github.com/theupdateframework/taps/blob/master/tap6.md):
-            Include specification version in metadata
-        - [TAP 9](https://github.com/theupdateframework/taps/blob/master/tap9.md):
-            Mandatory Metadata signing schemes
-        - [Tap 10](https://github.com/theupdateframework/taps/blob/master/tap10.md):
-           Remove native support for compressed metadata
-        - [TAP 11](https://github.com/theupdateframework/taps/blob/master/tap11.md):
-           Using POUFs for Interoperability
-
-	   Implementations compliant with this version (1.0.0) of the specification
-       must also comply with the TAPs mentioned above.
-
-## **2. System overview**
-
-   The framework ultimately provides a secure method of obtaining trusted
-   files.  To avoid ambiguity, we will refer to the files the framework is used
-   to distribute as "target files".  Target files are opaque to the framework.
-   Whether target files are packages containing multiple files, single text
-   files, or executable binaries is irrelevant to the framework.
-
-   The metadata describing target files is the information necessary to
-   securely identify the file and indicate which roles are trusted to provide
-   the file.  As providing additional information about
-   target files may be important to some software update systems using the
-   framework, additional arbitrary information can be provided with any target
-   file. This information will be included in signed metadata that describes
-   the target files.
-
-   The following are the high-level steps of using the framework from the
-   viewpoint of a software update system using the framework.  This is an
-   error-free case.
-
-       Polling:
-            Periodically, the software update system using the framework
-            instructs the framework to check each repository for updates.  If
-            the framework reports to the application code that there are
-            updates, the application code determines whether it wants to
-            download the updated target files.  Only target files that are
-            trusted (referenced by properly signed and timely metadata) are
-            made available by the framework.
-
-       Fetching:
-            For each file that the application wants, it asks the framework to
-            download the file.  The framework downloads the file and performs
-            security checks to ensure that the downloaded file is exactly what
-            is expected according to the signed metadata.  The application code
-            is not given access to the file until the security checks have been
-            completed.  The application asks the framework to copy the
-            downloaded file to a location specified by the application.  At
-            this point, the application has securely obtained the target file
-            and can do with it whatever it wishes.
-
-* **2.1. Roles and PKI**
-
-   In the discussion of roles that follows, it is important to remember that
-   the framework has been designed to allow a large amount of flexibility for
-   many different use cases.  For example, it is possible to use the framework
-   with a single key that is the only key used in the entire system.  This is
-   considered to be insecure but the flexibility is provided in order to meet
-   the needs of diverse use cases.
-
-   There are four fundamental top-level roles in the framework:
-     - Root role
-     - Targets role
-     - Snapshot role
-     - Timestamp role
-
-   There is also one optional top-level role:
-     - Mirrors role
-
-   All roles can use one or more keys and require a threshold of signatures of
-   the role's keys in order to trust a given metadata file.
-
-  - **2.1.1. Root role**
-
-      + The root role delegates trust to specific keys trusted for all other
-   top-level roles used in the system.
-
-      + The client-side of the framework MUST ship with trusted root keys for each
-   configured repository.
-
-      + The root role's private keys MUST be kept very secure and thus should be
-   kept offline.  If less than a threshold of Root keys are compromised, the
-   repository should revoke trust on the compromised keys.  This can be
-   accomplished with a normal rotation of root keys, covered in section 6.1
-   (Key management and migration). If a threshold of root keys is compromised,
-   the Root keys should be updated out-of-band, however, the threshold should
-   be chosen so that this is extremely unlikely.  In the unfortunate event that
-   a threshold of keys are compromised, it is safest to assume that attackers
-   have installed malware and taken over affected machines.  For this reason,
-   making it difficult for attackers to compromise all of the offline keys is
-   important because safely recovering from it is nearly impossible.
-
-
-  - **2.1.2 Targets role**
-
-      The targets role's signature indicates which target files are trusted by
-      clients.  The targets role signs metadata that describes these files, not
-      the actual target files themselves.
-
-      In addition, the targets role can delegate full or partial trust to other
-  roles.  Delegating trust means that the targets role indicates another role
-  (that is, another set of keys and the threshold required for trust) is
-  trusted to sign target file metadata.  Partial trust delegation is when the
-  delegated role is only trusted for some of the target files that the
-  delegating role is trusted for.
-
-      Delegated roles can further delegate trust to other delegated
-  roles.  This provides for multiple levels of trust delegation where each
-  role can delegate full or partial trust for the target files they are
-  trusted for.  The delegating role in these cases is still trusted.  That is,
-  a role does not become untrusted when it has delegated trust.
-
-      Any delegation can be revoked at any time: the delegating role needs only
-  to sign new metadata that no longer contains that delegation.
-
-  - **2.1.3 Snapshot role**
-
-      The snapshot role signs a metadata file that provides information about
-      the latest version of all targets metadata on the repository
-      (the top-level targets role and all delegated roles).  This information allows
-      clients to know which metadata files have been updated and also prevents
-      mix-and-match attacks.
-
-  - **2.1.4 Timestamp role**
-
-      To prevent an adversary from replaying an out-of-date signed metadata file
-      whose signature has not yet expired, an automated process periodically signs
-      a timestamped statement containing the hash of the snapshot file.  Even
-      though this timestamp key must be kept online, the risk posed to clients by
-      the compromise of this key is minimal.
-
-  - **2.1.5 Mirrors role**
-
-      Every repository has one or more mirrors from which files can be downloaded
-      by clients.  A software update system using the framework may choose to
-      hard-code the mirror information in their software or they may choose to use
-      mirror metadata files that can optionally be signed by a mirrors role.
-
-      The importance of using signed mirror lists depends on the application and
-      the users of that application.  There is minimal risk to the application's
-      security from being tricked into contacting the wrong mirrors.  This is
-      because the framework has very little trust in repositories.
-
-* **2.2. Threat model and analysis**
-
-   We assume an adversary who can respond to client requests, whether by acting
-   as a man-in-the-middle or through compromising repository mirrors.  At
-   worst, such an adversary can deny updates to users if no good mirrors are
-   accessible.  An inability to obtain updates is noticed by the framework.
-
-   If an adversary compromises enough keys to sign metadata, the best that can
-   be done is to limit the number of users who are affected.  The level to
-   which this threat is mitigated is dependent on how the application is using
-   the framework.  This includes whether different keys have been used for
-   different signing roles.
-
-   A detailed threat analysis is outside the scope of this document.  This is
-   partly because the specific threat posted to clients in many situations is
-   largely determined by how the framework is being used.
-
-*  **2.3. Protocol, Operations, Usage, and Format (POUF) Documents**
-
-    This specification purposefully leaves many implementation details,
-    including the metadata file formats, to the discretion of individual
-    implementations. These details do not affect the security of an
-    implementation, and so leaving them out of the specification allows this
-    document to support a greater variety of users. TUF implementers are
-    encouraged to document the wireline format and design decisions used in
-    their implementation as a POUF document. POUFs, as described in
-    [TAP 11](https://github.com/theupdateframework/taps/blob/master/tap11.md),
-    allow different adopters to create interoperable implementations of TUF.
-    POUFs should follow the layout described in TAP 11 and may be made
-    publicly available in the [TAP directory](https://github.com/theupdateframework/taps/tree/master/POUFs).
-
-## **3. The repository**
-
-   An application uses the framework to interact with one or more repositories.
-   A repository is a conceptual source of target files of interest to the
-   application.  Each repository has one or more mirrors which are the actual
-   providers of files to be downloaded.  For example, each mirror may specify a
-   different host where files can be downloaded from over HTTP.
-
-   The mirrors can be full or partial mirrors as long as the application-side
-   of the framework can ultimately obtain all of the files it needs.  A mirror
-   is a partial mirror if it is missing files that a full mirror should have.
-   If a mirror is intended to only act as a partial mirror, the metadata and
-   target paths available from that mirror can be specified.
-
-   Roles, trusted keys, and target files are completely separate between
-   repositories.  A multi-repository setup is a multi-root system.  When an
-   application uses the framework with multiple repositories, the framework
-   does not perform any "mixing" of the trusted content from each repository.
-   It is up to the application to determine the significance of the same or
-   different target files provided from separate repositories.
-
-* **3.1 Repository layout**
-
-   The filesystem layout in the repository is used for two purposes:
-     - To give mirrors an easy way to mirror only some of the repository.
-     - To specify which parts of the repository a given role has authority
-       to sign/provide.
-
- + **3.1.1 Target files**
-
-   The filenames and the directory structure of target files available from
-   a repository are not specified by the framework.  The names of these files
-   and directories are completely at the discretion of the application using
-   the framework.
-
- + **3.1.2 Metadata files**
-
-   The filenames and directory structure of repository metadata are strictly
-   defined.  All metadata filenames will have an extension (EXT) based on the
-   metaformat, for example JSON metadata files would have an EXT of json.
-   The following are the metadata files of top-level roles relative
-   to the base URL of metadata available from a given repository mirror.
+### Goals for implementation ### {#goals-for-implementation}
 
-    /root.EXT
-
-         Signed by the root keys; specifies trusted keys for the other
-         top-level roles.
-
-    /snapshot.EXT
++ The client side of the framework must be straightforward to implement in any
+  programming language and for any platform with the requisite networking and
+  crypto support.
 
-         Signed by the snapshot role's keys.  Lists the version numbers of all
-         target metadata files: the top-level targets.EXT and all delegated
-         roles.
++ The process by which developers push updates to the repository must be
+  simple.
 
-    /targets.EXT
++ The framework must be secure to use in environments that lack support for
+  SSL (TLS).  This does not exclude the optional use of SSL when available,
+  but the framework will be designed without it.
 
-         Signed by the target role's keys.  Lists hashes and sizes of target
-         files. Specifies delegation information and trusted keys for delegated
-         target roles.
+### Goals to protect against specific attacks ### {#goals-to-protect-against-specific-attacks}
 
-    /timestamp.EXT
+Note: When saying the framework protects against an attack, it means the
+attack will be unsuccessful.  It does not mean that a client will always
+successfully update during an attack.  Fundamentally, an attacker
+positioned to intercept and modify a client's communication can always
+perform a denial of service.  Nevertheless, the framework must detect
+when a client is unable to update.
+
++ **Arbitrary installation attacks.** An attacker cannot install anything
+  they want on the client system. That is, an attacker cannot provide
+  arbitrary files in response to download requests.
+
++ **Endless data attacks.**  An attacker cannot respond to client
+  requests with huge amounts of data (extremely large files) that interfere
+  with the client's system.
+
++ **Extraneous dependencies attacks.**  An attacker cannot cause clients
+  to download or install software dependencies that are not the intended
+  dependencies.
+
++ **Fast-forward attacks.**  An attacker cannot arbitrarily increase the
+  version numbers of metadata files, listed in the snapshot metadata, well
+  beyond the current value and thus tricking a software update system into
+  thinking any subsequent updates are trying to rollback the package to a
+  previous, out-of-date version.  In some situations, such as those where
+  there is a maximum possible version number, the perpetrator cannot use a
+  number so high that the system would never be able to match it with the
+  one in the snapshot metadata, and thus new updates could never be
+  downloaded.
+
++ **Indefinite freeze attacks.**  An attacker cannot respond to client
+  requests with the same, outdated metadata without the client being aware
+  of the problem.
+
++ **Malicious mirrors preventing updates.**  A repository mirror cannot
+  prevent updates from good mirrors.
+
++ **Mix-and-match attacks.**  An attacker cannot trick clients into using
+  a combination of metadata that never existed together on the repository
+  at the same time.
+
++ **Rollback attacks.**  An attacker cannot trick clients into installing
+  software that is older than that which the client previously knew to be
+  available.
+
++ **Vulnerability to key compromises.** An attacker, who is able to
+  compromise a single key or less than a given threshold of keys, cannot
+  compromise clients.  This includes compromising a single online key (such
+  as only being protected by SSL) or a single offline key (such as most
+  software update systems use to sign files).
+
++ **Wrong software installation.**  An attacker cannot provide a file
+  (trusted or untrusted) that is not the one the client wanted.
+
+### Goals for PKI ### {#goals-for-pki}
+
+* Software update systems using the framework's client code interface should
+  never have to directly manage keys.
+
+* All keys must be easily and safely revocable.  Trusting new keys for a role
+  must be easy.
+
+* For roles where trust delegation is meaningful, a role should be able to
+  delegate full or limited trust to another role.
+
+* The root of trust must not rely on external PKI.  That is, no authority will
+  be derived from keys outside of the framework.
+
+### TUF Augmentation Proposal (TAP) support ### {#tuf-augmentation-proposal-tap-support}
+
+This version (1.0.0) of the specification adheres to the following TAPS:
+
+- [TAP 6](https://github.com/theupdateframework/taps/blob/master/tap6.md):
+    Include specification version in metadata
+- [TAP 9](https://github.com/theupdateframework/taps/blob/master/tap9.md):
+    Mandatory Metadata signing schemes
+- [Tap 10](https://github.com/theupdateframework/taps/blob/master/tap10.md):
+    Remove native support for compressed metadata
+- [TAP 11](https://github.com/theupdateframework/taps/blob/master/tap11.md):
+    Using POUFs for Interoperability
+
+Implementations compliant with this version (1.0.0) of the specification
+must also comply with the TAPs mentioned above.
+
+# System overview # {#system-overview}
+
+The framework ultimately provides a secure method of obtaining trusted
+files.  To avoid ambiguity, we will refer to the files the framework is used
+to distribute as "target files".  Target files are opaque to the framework.
+Whether target files are packages containing multiple files, single text
+files, or executable binaries is irrelevant to the framework.
+
+The metadata describing target files is the information necessary to
+securely identify the file and indicate which roles are trusted to provide
+the file.  As providing additional information about
+target files may be important to some software update systems using the
+framework, additional arbitrary information can be provided with any target
+file. This information will be included in signed metadata that describes
+the target files.
+
+The following are the high-level steps of using the framework from the
+viewpoint of a software update system using the framework.  This is an
+error-free case.
+
+  Polling:
+      Periodically, the software update system using the framework
+      instructs the framework to check each repository for updates.  If
+      the framework reports to the application code that there are
+      updates, the application code determines whether it wants to
+      download the updated target files.  Only target files that are
+      trusted (referenced by properly signed and timely metadata) are
+      made available by the framework.
+
+  Fetching:
+      For each file that the application wants, it asks the framework to
+      download the file.  The framework downloads the file and performs
+      security checks to ensure that the downloaded file is exactly what
+      is expected according to the signed metadata.  The application code
+      is not given access to the file until the security checks have been
+      completed.  The application asks the framework to copy the
+      downloaded file to a location specified by the application.  At
+      this point, the application has securely obtained the target file
+      and can do with it whatever it wishes.
+
+## Roles and PKI ## {#roles-and-pki}
+
+In the discussion of roles that follows, it is important to remember that
+the framework has been designed to allow a large amount of flexibility for
+many different use cases.  For example, it is possible to use the framework
+with a single key that is the only key used in the entire system.  This is
+considered to be insecure but the flexibility is provided in order to meet
+the needs of diverse use cases.
+
+There are four fundamental top-level roles in the framework:
+- Root role
+- Targets role
+- Snapshot role
+- Timestamp role
+
+There is also one optional top-level role:
+- Mirrors role
+
+All roles can use one or more keys and require a threshold of signatures of
+the role's keys in order to trust a given metadata file.
+
+### Root role ### {#root}
+
+The root role delegates trust to specific keys trusted for all other
+top-level roles used in the system.
+
+The client-side of the framework MUST ship with trusted root keys for each
+configured repository.
+
+The root role's private keys MUST be kept very secure and thus should be
+kept offline.  If less than a threshold of Root keys are compromised, the
+repository should revoke trust on the compromised keys.  This can be
+accomplished with a normal rotation of root keys, covered in section 6.1
+(Key management and migration). If a threshold of root keys is compromised,
+the Root keys should be updated out-of-band, however, the threshold should
+be chosen so that this is extremely unlikely.  In the unfortunate event that
+a threshold of keys are compromised, it is safest to assume that attackers
+have installed malware and taken over affected machines.  For this reason,
+making it difficult for attackers to compromise all of the offline keys is
+important because safely recovering from it is nearly impossible.
+
+
+### Targets role ### {#targets}
+
+The targets role's signature indicates which target files are trusted by
+clients.  The targets role signs metadata that describes these files, not
+the actual target files themselves.
+
+In addition, the targets role can delegate full or partial trust to other
+roles.  Delegating trust means that the targets role indicates another role
+(that is, another set of keys and the threshold required for trust) is
+trusted to sign target file metadata.  Partial trust delegation is when the
+delegated role is only trusted for some of the target files that the
+delegating role is trusted for.
+
+Delegated roles can further delegate trust to other delegated
+roles.  This provides for multiple levels of trust delegation where each
+role can delegate full or partial trust for the target files they are
+trusted for.  The delegating role in these cases is still trusted.  That is,
+a role does not become untrusted when it has delegated trust.
+
+Any delegation can be revoked at any time: the delegating role needs only
+to sign new metadata that no longer contains that delegation.
+
+### Snapshot role ### {#snapshot}
+
+The snapshot role signs a metadata file that provides information about
+the latest version of all targets metadata on the repository
+(the top-level targets role and all delegated roles).  This information allows
+clients to know which metadata files have been updated and also prevents
+mix-and-match attacks.
+
+### Timestamp role ### {#timestamp}
+
+To prevent an adversary from replaying an out-of-date signed metadata file
+whose signature has not yet expired, an automated process periodically signs
+a timestamped statement containing the hash of the snapshot file.  Even
+though this timestamp key must be kept online, the risk posed to clients by
+the compromise of this key is minimal.
+
+### Mirrors role ### {#mirrors}
+
+Every repository has one or more mirrors from which files can be downloaded
+by clients.  A software update system using the framework may choose to
+hard-code the mirror information in their software or they may choose to use
+mirror metadata files that can optionally be signed by a mirrors role.
+
+The importance of using signed mirror lists depends on the application and
+the users of that application.  There is minimal risk to the application's
+security from being tricked into contacting the wrong mirrors.  This is
+because the framework has very little trust in repositories.
+
+## Threat model and analysis ## {#threat-model-and-analysis}
+
+We assume an adversary who can respond to client requests, whether by acting
+as a man-in-the-middle or through compromising repository mirrors.  At
+worst, such an adversary can deny updates to users if no good mirrors are
+accessible.  An inability to obtain updates is noticed by the framework.
+
+If an adversary compromises enough keys to sign metadata, the best that can
+be done is to limit the number of users who are affected.  The level to
+which this threat is mitigated is dependent on how the application is using
+the framework.  This includes whether different keys have been used for
+different signing roles.
+
+A detailed threat analysis is outside the scope of this document.  This is
+partly because the specific threat posted to clients in many situations is
+largely determined by how the framework is being used.
+
+## Protocol, Operations, Usage, and Format (POUF) documents ## {#pouf-documents}
+
+This specification purposefully leaves many implementation details,
+including the metadata file formats, to the discretion of individual
+implementations. These details do not affect the security of an
+implementation, and so leaving them out of the specification allows this
+document to support a greater variety of users. TUF implementers are
+encouraged to document the wireline format and design decisions used in
+their implementation as a POUF document. POUFs, as described in
+[TAP 11](https://github.com/theupdateframework/taps/blob/master/tap11.md),
+allow different adopters to create interoperable implementations of TUF.
+POUFs should follow the layout described in TAP 11 and may be made
+publicly available in the [TAP directory](https://github.com/theupdateframework/taps/tree/master/POUFs).
+
+# The repository # {#the-repository}
+
+An application uses the framework to interact with one or more repositories.
+A repository is a conceptual source of target files of interest to the
+application.  Each repository has one or more mirrors which are the actual
+providers of files to be downloaded.  For example, each mirror may specify a
+different host where files can be downloaded from over HTTP.
+
+The mirrors can be full or partial mirrors as long as the application-side
+of the framework can ultimately obtain all of the files it needs.  A mirror
+is a partial mirror if it is missing files that a full mirror should have.
+If a mirror is intended to only act as a partial mirror, the metadata and
+target paths available from that mirror can be specified.
+
+Roles, trusted keys, and target files are completely separate between
+repositories.  A multi-repository setup is a multi-root system.  When an
+application uses the framework with multiple repositories, the framework
+does not perform any "mixing" of the trusted content from each repository.
+It is up to the application to determine the significance of the same or
+different target files provided from separate repositories.
+
+## Repository layout ## {#repository-layout}
+
+The filesystem layout in the repository is used for two purposes:
+- To give mirrors an easy way to mirror only some of the repository.
+- To specify which parts of the repository a given role has authority
+  to sign/provide.
+
+### Target files ### {#target-files}
+
+The filenames and the directory structure of target files available from
+a repository are not specified by the framework.  The names of these files
+and directories are completely at the discretion of the application using
+the framework.
 
-         Signed by the timestamp role's keys.  Lists hash(es), size, and version
-         number of the snapshot file.  This is the first and potentially only
-         file that needs to be downloaded when clients poll for the existence
-         of updates.
+### Metadata files ### {#metadata-files}
 
-    /mirrors.EXT (optional)
+The filenames and directory structure of repository metadata are strictly
+defined.  All metadata filenames will have an extension (EXT) based on the
+metaformat, for example JSON metadata files would have an EXT of json.
+The following are the metadata files of top-level roles relative
+to the base URL of metadata available from a given repository mirror.
 
-         Signed by the mirrors role's keys.  Lists information about available
-         mirrors and the content available from each mirror.
+  /root.EXT
 
-  + **3.1.2.1 Metadata files for targets delegation**
+    Signed by the root keys; specifies trusted keys for the other
+    top-level roles.
 
-   When the targets role delegates trust to other roles, each delegated role
-   provides one signed metadata file.  As is the case with the directory
-   structure of top-level metadata, the delegated files are relative to the
-   base URL of metadata available from a given repository mirror.
+  /snapshot.EXT
 
-   A delegated role file is located at:
+    Signed by the snapshot role's keys.  Lists the version numbers of all
+    target metadata files: the top-level targets.EXT and all delegated
+    roles.
 
-    /DELEGATED_ROLE.EXT
+  /targets.EXT
 
-   where DELEGATED_ROLE is the name of the delegated role that has been
-   specified in targets.EXT.  If this role further delegates trust to a role
-   named ANOTHER_ROLE, that role's signed metadata file is made available at:
+    Signed by the target role's keys.  Lists hashes and sizes of target
+    files. Specifies delegation information and trusted keys for delegated
+    target roles.
 
-    /ANOTHER_ROLE.EXT
+  /timestamp.EXT
 
-   Delegated target roles are authorized by the keys listed in the directly
-   delegating target role.
+    Signed by the timestamp role's keys.  Lists hash(es), size, and version
+    number of the snapshot file.  This is the first and potentially only
+    file that needs to be downloaded when clients poll for the existence
+    of updates.
 
-## **4. Document formats**
+  /mirrors.EXT (optional)
 
-   All of the formats described below include the ability to add more
-   attribute-value fields for backwards-compatible format changes.  If
-   a backwards incompatible format change is needed, a new filename can
-   be used.
+    Signed by the mirrors role's keys.  Lists information about available
+    mirrors and the content available from each mirror.
 
-* **4.1. Metaformat**
+#### Metadata files for targets delegation #### {#metadata-files-for-targets-delegation}
 
-   Implementers of TUF may use any data format for metadata files as long as
-   all fields in this specification are included and TUF clients are able to
-   interpret them without ambiguity. Implementers should choose a data format
-   that allows for canonicalization, or one that will decode data
-   deterministically by default so that signatures can be accurately verified.
-   The chosen data format should be documented in the POUF of the implementation.
-   The examples in this document use a subset of the JSON object format, with
-   floating-point numbers omitted.  When calculating the digest of an
-   object, we use the "canonical JSON" subdialect as described at
-        http://wiki.laptop.org/go/Canonical_JSON
+When the targets role delegates trust to other roles, each delegated role
+provides one signed metadata file.  As is the case with the directory
+structure of top-level metadata, the delegated files are relative to the
+base URL of metadata available from a given repository mirror.
 
-* **4.2. File formats: general principles**
+A delegated role file is located at:
 
-   All signed metadata objects have the format:
+  /DELEGATED_ROLE.EXT
 
-       { "signed" : ROLE,
-         "signatures" : [
-            { "keyid" : KEYID,
-              "sig" : SIGNATURE }
-            , ... ]
-       }
+where DELEGATED_ROLE is the name of the delegated role that has been
+specified in targets.EXT.  If this role further delegates trust to a role
+named ANOTHER_ROLE, that role's signed metadata file is made available at:
 
-   where:
+  /ANOTHER_ROLE.EXT
 
-          ROLE is a dictionary whose "_type" field describes the role type.
+Delegated target roles are authorized by the keys listed in the directly
+delegating target role.
 
-          KEYID is the identifier of the key signing the ROLE dictionary.
+# Document formats # {#document-formats}
 
-          SIGNATURE is a hex-encoded signature of the canonical form of
-          the metadata for ROLE.
+All of the formats described below include the ability to add more
+attribute-value fields for backwards-compatible format changes.  If
+a backwards incompatible format change is needed, a new filename can
+be used.
 
+## Metaformat ## {#metaformat}
 
-   All keys have the format:
+Implementers of TUF may use any data format for metadata files as long as
+all fields in this specification are included and TUF clients are able to
+interpret them without ambiguity. Implementers should choose a data format
+that allows for canonicalization, or one that will decode data
+deterministically by default so that signatures can be accurately verified.
+The chosen data format should be documented in the POUF of the implementation.
+The examples in this document use a subset of the JSON object format, with
+floating-point numbers omitted.  When calculating the digest of an
+object, we use the "canonical JSON" subdialect as described at
+    http://wiki.laptop.org/go/Canonical_JSON
 
-        { "keytype" : KEYTYPE,
-          "scheme" : SCHEME,
-          "keyval" : KEYVAL
-        }
+## File formats: general principles ## {#file-formats-general-principles}
 
-   where:
+All signed metadata objects have the format:
 
-          KEYTYPE is a string denoting a public key signature system, such
-          as RSA or ECDSA.
+    { "signed" : ROLE,
+      "signatures" : [
+        { "keyid" : KEYID,
+          "sig" : SIGNATURE }
+        , ... ]
+    }
 
-          SCHEME is a string denoting a corresponding signature scheme.  For
-          example: "rsassa-pss-sha256" and "ecdsa-sha2-nistp256".
+where:
 
-          KEYVAL is a dictionary containing the public portion of the key.
+      ROLE is a dictionary whose "_type" field describes the role type.
 
-   The reference implementation defines three signature schemes, although TUF
-   is not restricted to any particular signature scheme, key type, or
-   cryptographic library:
+      KEYID is the identifier of the key signing the ROLE dictionary.
 
-       "rsassa-pss-sha256" : RSA Probabilistic signature scheme with appendix.
-        The underlying hash function is SHA256.
-        https://tools.ietf.org/html/rfc3447#page-29
+      SIGNATURE is a hex-encoded signature of the canonical form of
+      the metadata for ROLE.
 
-       "ed25519" : Elliptic curve digital signature algorithm based on Twisted
-        Edwards curves.
-        https://ed25519.cr.yp.to/
 
-        "ecdsa-sha2-nistp256" : Elliptic Curve Digital Signature Algorithm
-         with NIST P-256 curve signing and SHA-256 hashing.
-         https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+All keys have the format:
 
-   We define three keytypes below: 'rsa', 'ed25519', and 'ecdsa', but adopters
-   can define and use any particular keytype, signing scheme, and cryptographic
-   library.
+    { "keytype" : KEYTYPE,
+      "scheme" : SCHEME,
+      "keyval" : KEYVAL
+    }
 
-   The 'rsa' format is:
+where:
 
-        { "keytype" : "rsa",
-          "scheme" : "rsassa-pss-sha256",
-          "keyval" : {"public" : PUBLIC}
-        }
+      KEYTYPE is a string denoting a public key signature system, such
+      as RSA or ECDSA.
 
-   where PUBLIC is in PEM format and a string.  All RSA keys MUST be at least
-   2048 bits.
-
-   The 'ed25519' format is:
-
-        { "keytype" : "ed25519",
-          "scheme" : "ed25519",
-          "keyval" : {"public" : PUBLIC}
-        }
-
-   where:
-
-          PUBLIC is a 64-byte hex encoded string.
-
-   The 'ecdsa' format is:
-
-        { "keytype" : "ecdsa-sha2-nistp256",
-          "scheme" : "ecdsa-sha2-nistp256",
-          "keyval" : {"public" : PUBLIC}
-        }
-
-   where:
-
-        PUBLIC is in PEM format and a string.
-
-   The KEYID of a key is the hexdigest of the SHA-256 hash of the
-   canonical form of the key.
-
-   Metadata date-time data follows the ISO 8601 standard.  The expected format
-   of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is
-   always in UTC, and the "Z" time zone designator is attached to indicate a
-   zero UTC offset.  An example date-time string is "1985-10-21T01:21:00Z".
-
-
-* **4.3. File formats: root.json**
-
-   The root.json file is signed by the root role's keys.  It indicates
-   which keys are authorized for all top-level roles, including the root
-   role itself.  Revocation and replacement of top-level role keys, including
-   for the root role, is done by changing the keys listed for the roles in
-   this file.
-
-   The "signed" portion of root.json is as follows:
-
-       { "_type" : "root",
-         "spec_version" : SPEC_VERSION,
-         "consistent_snapshot": CONSISTENT_SNAPSHOT,
-         "version" : VERSION,
-         "expires" : EXPIRES,
-         "keys" : {
-             KEYID : KEY
-             , ... },
-         "roles" : {
-             ROLE : {
-               "keyids" : [ KEYID, ... ] ,
-               "threshold" : THRESHOLD }
-             , ... }
-       }
-
-   SPEC_VERSION is a string that contains the version number of the TUF
-   specification. Its format follows the [Semantic Versioning 2.0.0
-   (semver)](https://semver.org/spec/v2.0.0.html) specification. Metadata is
-   written according to version "spec_version" of the specification, and
-   clients MUST verify that "spec_version" matches the expected version number.
-   Adopters are free to determine what is considered a match (e.g., the version
-   number exactly, or perhaps only the major version number (major.minor.fix).
-
-   CONSISTENT_SNAPSHOT is a boolean indicating whether the repository supports
-   consistent snapshots.  Section 7 goes into more detail on the consequences
-   of enabling this setting on a repository.
-
-   VERSION is an integer that is greater than 0.  Clients MUST NOT replace a
-   metadata file with a version number less than the one currently trusted.
-
-   EXPIRES determines when metadata should be considered expired and no longer
-   trusted by clients.  Clients MUST NOT trust an expired file.
-
-   A ROLE is one of "root", "snapshot", "targets", "timestamp", or "mirrors".
-   A role for each of "root", "snapshot", "timestamp", and "targets" MUST be
-   specified in the key list. The role of "mirror" is OPTIONAL.  If not
-   specified, the mirror list will not need to be signed if mirror lists are
-   being used.
-
-   The KEYID MUST be correct for the specified KEY.  Clients MUST calculate
-   each KEYID to verify this is correct for the associated key.  Clients MUST
-   ensure that for any KEYID represented in this key list and in other files,
-   only one unique key has that KEYID.
-
-   The THRESHOLD for a role is an integer of the number of keys of that role
-   whose signatures are required in order to consider a file as being properly
-   signed by that role.
-
-   A root.json example file:
-
-       {
-       "signatures": [
-        {
-         "keyid": "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4",
-         "sig": "a312b9c3cb4a1b693e8ebac5ee1ca9cc01f2661c14391917dcb111517f72370809
-                 f32c890c6b801e30158ac4efe0d4d87317223077784c7a378834249d048306"
-        }
-       ],
-       "signed": {
-        "_type": "root",
-        "spec_version": "1.0.0",
-        "consistent_snapshot": false,
-        "expires": "2030-01-01T00:00:00Z",
-        "keys": {
-         "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3": {
-          "keytype": "ed25519",
-          "scheme": "ed25519",
-          "keyval": {
-           "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"
-          }
-         },
-         "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164": {
-          "keytype": "ed25519",
-          "scheme": "ed25519",
-          "keyval": {
-           "public": "68ead6e54a43f8f36f9717b10669d1ef0ebb38cee6b05317669341309f1069cb"
-          }
-         },
-         "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4": {
-          "keytype": "ed25519",
-          "scheme": "ed25519",
-          "keyval": {
-           "public": "66dd78c5c2a78abc6fc6b267ff1a8017ba0e8bfc853dd97af351949bba021275"
-          }
-         },
-         "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc": {
-          "keytype": "ed25519",
-          "scheme": "ed25519",
-          "keyval": {
-           "public": "01c61f8dc7d77fcef973f4267927541e355e8ceda757e2c402818dad850f856e"
-          }
-         }
-        },
-        "roles": {
-         "root": {
-          "keyids": [
-           "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4"
-          ],
-          "threshold": 1
-         },
-         "snapshot": {
-          "keyids": [
-           "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc"
-          ],
-          "threshold": 1
-         },
-         "targets": {
-          "keyids": [
-           "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164"
-          ],
-          "threshold": 1
-         },
-         "timestamp": {
-          "keyids": [
-           "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
-          ],
-          "threshold": 1
-         }
-        },
-        "version": 1
-       }
+      SCHEME is a string denoting a corresponding signature scheme.  For
+      example: "rsassa-pss-sha256" and "ecdsa-sha2-nistp256".
+
+      KEYVAL is a dictionary containing the public portion of the key.
+
+The reference implementation defines three signature schemes, although TUF
+is not restricted to any particular signature scheme, key type, or
+cryptographic library:
+
+    "rsassa-pss-sha256" : RSA Probabilistic signature scheme with appendix.
+    The underlying hash function is SHA256.
+    https://tools.ietf.org/html/rfc3447#page-29
+
+    "ed25519" : Elliptic curve digital signature algorithm based on Twisted
+    Edwards curves.
+    https://ed25519.cr.yp.to/
+
+    "ecdsa-sha2-nistp256" : Elliptic Curve Digital Signature Algorithm
+      with NIST P-256 curve signing and SHA-256 hashing.
+      https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+
+We define three keytypes below: "rsa", "ed25519", and "ecdsa", but adopters
+can define and use any particular keytype, signing scheme, and cryptographic
+library.
+
+The "rsa" format is:
+
+    { "keytype" : "rsa",
+      "scheme" : "rsassa-pss-sha256",
+      "keyval" : {"public" : PUBLIC}
+    }
+
+where PUBLIC is in PEM format and a string.  All RSA keys MUST be at least
+2048 bits.
+
+The "ed25519" format is:
+
+    { "keytype" : "ed25519",
+      "scheme" : "ed25519",
+      "keyval" : {"public" : PUBLIC}
+    }
+
+where:
+
+      PUBLIC is a 64-byte hex encoded string.
+
+The "ecdsa" format is:
+
+    { "keytype" : "ecdsa-sha2-nistp256",
+      "scheme" : "ecdsa-sha2-nistp256",
+      "keyval" : {"public" : PUBLIC}
+    }
+
+where:
+
+    PUBLIC is in PEM format and a string.
+
+The KEYID of a key is the hexdigest of the SHA-256 hash of the
+canonical form of the key.
+
+Metadata date-time data follows the ISO 8601 standard.  The expected format
+of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is
+always in UTC, and the "Z" time zone designator is attached to indicate a
+zero UTC offset.  An example date-time string is "1985-10-21T01:21:00Z".
+
+
+## File formats: root.json ## {#file-formats-root}
+
+The root.json file is signed by the root role's keys.  It indicates
+which keys are authorized for all top-level roles, including the root
+role itself.  Revocation and replacement of top-level role keys, including
+for the root role, is done by changing the keys listed for the roles in
+this file.
+
+The "signed" portion of root.json is as follows:
+
+    { "_type" : "root",
+      "spec_version" : SPEC_VERSION,
+      "consistent_snapshot": CONSISTENT_SNAPSHOT,
+      "version" : VERSION,
+      "expires" : EXPIRES,
+      "keys" : {
+          KEYID : KEY
+          , ... },
+      "roles" : {
+          ROLE : {
+            "keyids" : [ KEYID, ... ] ,
+            "threshold" : THRESHOLD }
+          , ... }
+    }
+
+SPEC_VERSION is a string that contains the version number of the TUF
+specification. Its format follows the [Semantic Versioning 2.0.0
+(semver)](https://semver.org/spec/v2.0.0.html) specification. Metadata is
+written according to version "spec_version" of the specification, and
+clients MUST verify that "spec_version" matches the expected version number.
+Adopters are free to determine what is considered a match (e.g., the version
+number exactly, or perhaps only the major version number (major.minor.fix).
+
+CONSISTENT_SNAPSHOT is a boolean indicating whether the repository supports
+consistent snapshots.  Section 7 goes into more detail on the consequences
+of enabling this setting on a repository.
+
+VERSION is an integer that is greater than 0.  Clients MUST NOT replace a
+metadata file with a version number less than the one currently trusted.
+
+EXPIRES determines when metadata should be considered expired and no longer
+trusted by clients.  Clients MUST NOT trust an expired file.
+
+A ROLE is one of "root", "snapshot", "targets", "timestamp", or "mirrors".
+A role for each of "root", "snapshot", "timestamp", and "targets" MUST be
+specified in the key list. The role of "mirror" is OPTIONAL.  If not
+specified, the mirror list will not need to be signed if mirror lists are
+being used.
+
+The KEYID MUST be correct for the specified KEY.  Clients MUST calculate
+each KEYID to verify this is correct for the associated key.  Clients MUST
+ensure that for any KEYID represented in this key list and in other files,
+only one unique key has that KEYID.
+
+The THRESHOLD for a role is an integer of the number of keys of that role
+whose signatures are required in order to consider a file as being properly
+signed by that role.
+
+A root.json example file:
+
+    {
+    "signatures": [
+    {
+      "keyid": "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4",
+      "sig": "a312b9c3cb4a1b693e8ebac5ee1ca9cc01f2661c14391917dcb111517f72370809
+              f32c890c6b801e30158ac4efe0d4d87317223077784c7a378834249d048306"
+    }
+    ],
+    "signed": {
+    "_type": "root",
+    "spec_version": "1.0.0",
+    "consistent_snapshot": false,
+    "expires": "2030-01-01T00:00:00Z",
+    "keys": {
+      "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3": {
+      "keytype": "ed25519",
+      "scheme": "ed25519",
+      "keyval": {
+        "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"
       }
+      },
+      "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164": {
+      "keytype": "ed25519",
+      "scheme": "ed25519",
+      "keyval": {
+        "public": "68ead6e54a43f8f36f9717b10669d1ef0ebb38cee6b05317669341309f1069cb"
+      }
+      },
+      "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4": {
+      "keytype": "ed25519",
+      "scheme": "ed25519",
+      "keyval": {
+        "public": "66dd78c5c2a78abc6fc6b267ff1a8017ba0e8bfc853dd97af351949bba021275"
+      }
+      },
+      "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc": {
+      "keytype": "ed25519",
+      "scheme": "ed25519",
+      "keyval": {
+        "public": "01c61f8dc7d77fcef973f4267927541e355e8ceda757e2c402818dad850f856e"
+      }
+      }
+    },
+    "roles": {
+      "root": {
+      "keyids": [
+        "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4"
+      ],
+      "threshold": 1
+      },
+      "snapshot": {
+      "keyids": [
+        "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc"
+      ],
+      "threshold": 1
+      },
+      "targets": {
+      "keyids": [
+        "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164"
+      ],
+      "threshold": 1
+      },
+      "timestamp": {
+      "keyids": [
+        "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
+      ],
+      "threshold": 1
+      }
+    },
+    "version": 1
+    }
+  }
 
-* **4.4. File formats: snapshot.json**
+## File formats: snapshot.json ## {#file-formats-snapshot}
 
-   The snapshot.json file is signed by the snapshot role. It MUST list the
-   version numbers of the top-level targets metadata and all delegated targets
-   metadata. It MAY also list their lengths and file hashes.
+The snapshot.json file is signed by the snapshot role. It MUST list the
+version numbers of the top-level targets metadata and all delegated targets
+metadata. It MAY also list their lengths and file hashes.
 
-   The "signed" portion of snapshot.json is as follows:
+The "signed" portion of snapshot.json is as follows:
 
-       { "_type" : "snapshot",
-         "spec_version" : SPEC_VERSION,
-         "version" : VERSION,
-         "expires" : EXPIRES,
-         "meta" : METAFILES
-       }
+    { "_type" : "snapshot",
+      "spec_version" : SPEC_VERSION,
+      "version" : VERSION,
+      "expires" : EXPIRES,
+      "meta" : METAFILES
+    }
 
-   SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
+SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
 
-   METAFILES is an object whose format is the following:
+METAFILES is an object whose format is the following:
 
-       { METAPATH : {
-             "version" : VERSION,
-             ("length" : LENGTH,)
-             ("hashes" : HASHES) }
-         , ...
-       }
+    { METAPATH : {
+          "version" : VERSION,
+          ("length" : LENGTH,)
+          ("hashes" : HASHES) }
+      , ...
+    }
 
-   METAPATH is the file path of the metadata on the repository relative to the
-   metadata base URL. For snapshot.json, these are top-level targets metadata
-   and delegated targets metadata.
+METAPATH is the file path of the metadata on the repository relative to the
+metadata base URL. For snapshot.json, these are top-level targets metadata
+and delegated targets metadata.
 
-   VERSION is the integer version number as shown in the metadata file at
-   METAPATH.
+VERSION is the integer version number as shown in the metadata file at
+METAPATH.
 
-   LENGTH is the integer length in bytes of the metadata file at METAPATH. It
-   is OPTIONAL and can be omitted to reduce the snapshot metadata file size. In
-   that case the client MUST use a custom download limit for the listed
-   metadata.
+LENGTH is the integer length in bytes of the metadata file at METAPATH. It
+is OPTIONAL and can be omitted to reduce the snapshot metadata file size. In
+that case the client MUST use a custom download limit for the listed
+metadata.
 
-   HASHES is a dictionary that specifies one or more hashes of the metadata
-   file at METAPATH, including their cryptographic hash function. For example:
-   { "sha256": HASH, ... }. HASHES is OPTIONAL and can be omitted to reduce
-   the snapshot metadata file size.  In that case the repository MUST guarantee
-   that VERSION alone unambiguously identifies the metadata at METAPATH.
+HASHES is a dictionary that specifies one or more hashes of the metadata
+file at METAPATH, including their cryptographic hash function. For example:
+{ "sha256": HASH, ... }. HASHES is OPTIONAL and can be omitted to reduce
+the snapshot metadata file size.  In that case the repository MUST guarantee
+that VERSION alone unambiguously identifies the metadata at METAPATH.
 
-   A snapshot.json example file:
+A snapshot.json example file:
 
-       { "signatures": [
-         {
-          "keyid": "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc",
-          "sig": "f7f03b13e3f4a78a23561419fc0dd741a637e49ee671251be9f8f3fceedfc112e4
-                  4ee3aaff2278fad9164ab039118d4dc53f22f94900dae9a147aa4d35dcfc0f"
-         }
+    { "signatures": [
+      {
+      "keyid": "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc",
+      "sig": "f7f03b13e3f4a78a23561419fc0dd741a637e49ee671251be9f8f3fceedfc112e4
+              4ee3aaff2278fad9164ab039118d4dc53f22f94900dae9a147aa4d35dcfc0f"
+      }
+    ],
+    "signed": {
+      "_type": "snapshot",
+      "spec_version": "1.0.0",
+      "expires": "2030-01-01T00:00:00Z",
+      "meta": {
+      "targets.json": {
+        "version": 1
+      },
+      "project1.json": {
+        "version": 1,
+        "hashes": {
+        "sha256": "f592d072e1193688a686267e8e10d7257b4ebfcf28133350dae88362d82a0c8a"
+        }
+      },
+      "project2.json": {
+        "version": 1,
+        "length": 604,
+        "hashes": {
+        "sha256": "1f812e378264c3085bb69ec5f6663ed21e5882bbece3c3f8a0e8479f205ffb91"
+        }
+      }
+      },
+      "version": 1
+    }
+    }
+
+## File formats: targets.json and delegated target roles ## {#file-formats-targets}
+
+The "signed" portion of targets.json is as follows:
+
+    { "_type" : "targets",
+      "spec_version" : SPEC_VERSION,
+      "version" : VERSION,
+      "expires" : EXPIRES,
+      "targets" : TARGETS,
+      ("delegations" : DELEGATIONS)
+    }
+
+SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
+
+TARGETS is an object whose format is the following:
+
+    { TARGETPATH : {
+          "length" : LENGTH,
+          "hashes" : HASHES,
+          ("custom" : CUSTOM) }
+      , ...
+    }
+
+Each key of the TARGETS object is a TARGETPATH.  A TARGETPATH is a path to
+a file that is relative to a mirror's base URL of targets. To avoid
+surprising behavior when resolving paths, it is RECOMMENDED that a
+TARGETPATH uses the forward slash (/) as directory separator and does not
+start with a directory separator. The recommendation for TARGETPATH aligns
+with the ["path-relative-URL string"
+definition](https://url.spec.whatwg.org/#path-relative-url-string) in the
+WHATWG URL specification.
+
+It is allowed to have a TARGETS object with no TARGETPATH elements.  This
+can be used to indicate that no target files are available.
+
+LENGTH is the integer length in bytes of the target file at TARGETPATH.
+
+HASHES is a dictionary that specifies one or more hashes, including the
+cryptographic hash function.  For example: { "sha256": HASH, ... }. HASH is
+the hexdigest of the cryptographic function computed on the target file.
+
+If defined, the elements and values of the CUSTOM object will be made
+available to the client application.  The format of the CUSTOM object is
+opaque to the framework, which only needs to know that the "custom"
+attribute maps to an object.  The CUSTOM object may include version
+numbers, dependencies, requirements, or any other data that the application
+wants to include to describe the file at TARGETPATH.  The application may
+use this information to guide download decisions.
+
+DELEGATIONS is an object whose format is the following:
+
+    { "keys" : {
+          KEYID : KEY,
+          ... },
+      "roles" : [{
+          "name": ROLENAME,
+          "keyids" : [ KEYID, ... ] ,
+          "threshold" : THRESHOLD,
+          ("path_hash_prefixes" : [ HEX_DIGEST, ... ] |
+          "paths" : [ PATHPATTERN, ... ]),
+          "terminating": TERMINATING,
+      }, ... ]
+    }
+
+"keys" lists the public keys to verify signatures of delegated targets roles.
+Revocation and replacement of delegated targets roles keys is done by
+changing the keys in this field in the delegating role's metadata.
+
+ROLENAME is the name of the delegated role.  For example,
+"projects".
+
+TERMINATING is a boolean indicating whether subsequent delegations should be
+considered.
+
+As explained in the [Diplomat
+paper](https://github.com/theupdateframework/tuf/blob/develop/docs/papers/protect-community-repositories-nsdi2016.pdf),
+terminating delegations instruct the client not to consider future trust
+statements that match the delegation's pattern, which stops the delegation
+processing once this delegation (and its descendants) have been processed.
+A terminating delegation for a package causes any further statements about a
+package that are not made by the delegated party or its descendants to be
+ignored.
+
+In order to discuss target paths, a role MUST specify only one of the
+"path_hash_prefixes" or "paths" attributes, each of which we discuss next.
+
+The "path_hash_prefixes" list is used to succinctly describe a set of target
+paths. Specifically, each HEX_DIGEST in "path_hash_prefixes" describes a set
+of target paths; therefore, "path_hash_prefixes" is the union over each
+prefix of its set of target paths. The target paths must meet this
+condition: each target path, when hashed with the SHA-256 hash function to
+produce a 64-byte hexadecimal digest (HEX_DIGEST), must share the same
+prefix as one of the prefixes in "path_hash_prefixes". This is useful to
+split a large number of targets into separate bins identified by consistent
+hashing.
+
+The "paths" list describes paths that the role is trusted to provide.
+Clients MUST check that a target is in one of the trusted paths of all roles
+in a delegation chain, not just in a trusted path of the role that describes
+the target file.  PATHPATTERN can include shell-style wildcards and supports
+the Unix filename pattern matching convention.  Its format may either
+indicate a path to a single file, or to multiple paths with the use of
+shell-style wildcards.  For example, the path pattern "targets/*.tgz" would
+match file paths "targets/foo.tgz" and "targets/bar.tgz", but not
+"targets/foo.txt".  Likewise, path pattern "foo-version-?.tgz" matches
+"foo-version-2.tgz" and "foo-version-a.tgz", but not "foo-version-alpha.tgz".
+To avoid surprising behavior when matching targets with PATHPATTERN, it is
+RECOMMENDED that PATHPATTERN uses the forward slash (/) as directory
+separator and does not start with a directory separator, akin to
+TARGETSPATH.
+
+
+Prioritized delegations allow clients to resolve conflicts between delegated
+roles that share responsibility for overlapping target paths.  To resolve
+conflicts, clients must consider metadata in order of appearance of delegations;
+we treat the order of delegations such that the first delegation is trusted
+over the second one, the second delegation is trusted more than the third
+one, and so on. Likewise, the metadata of the first delegation will override that
+of the second delegation, the metadata of the second delegation will override
+that of the third one, etc. In order to accommodate prioritized
+delegations, the "roles" key in the DELEGATIONS object above points to an array
+of delegated roles, rather than to a hash table.
+
+The metadata files for delegated target roles has the same format as the
+top-level targets.json metadata file.
+
+A targets.json example file:
+
+    {
+    "signatures": [
+    {
+      "keyid": "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164",
+      "sig": "e9fd40008fba263758a3ff1dc59f93e42a4910a282749af915fbbea1401178e5a0
+              12090c228f06db1deb75ad8ddd7e40635ac51d4b04301fce0fd720074e0209"
+    }
+    ],
+    "signed": {
+    "_type": "targets",
+    "spec_version": "1.0.0",
+    "delegations": {
+      "keys": {
+      "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6": {
+        "keytype": "ed25519",
+        "scheme": "ed25519",
+        "keyval": {
+        "public": "b6e40fb71a6041212a3d84331336ecaa1f48a0c523f80ccc762a034c727606fa"
+        }
+      }
+      },
+      "roles": [
+      {
+        "keyids": [
+        "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6"
         ],
-        "signed": {
-         "_type": "snapshot",
-         "spec_version": "1.0.0",
-         "expires": "2030-01-01T00:00:00Z",
-         "meta": {
-          "targets.json": {
-           "version": 1
-          },
-          "project1.json": {
-           "version": 1,
-           "hashes": {
-            "sha256": "f592d072e1193688a686267e8e10d7257b4ebfcf28133350dae88362d82a0c8a"
-           }
-          },
-          "project2.json": {
-           "version": 1,
-           "length": 604,
-           "hashes": {
-            "sha256": "1f812e378264c3085bb69ec5f6663ed21e5882bbece3c3f8a0e8479f205ffb91"
-           }
-          }
-         },
-         "version": 1
-        }
-       }
-
-* **4.5. File formats: targets.json and delegated target roles**
-
-   The "signed" portion of targets.json is as follows:
-
-       { "_type" : "targets",
-         "spec_version" : SPEC_VERSION,
-         "version" : VERSION,
-         "expires" : EXPIRES,
-         "targets" : TARGETS,
-         ("delegations" : DELEGATIONS)
-       }
-
-   SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
-
-   TARGETS is an object whose format is the following:
-
-       { TARGETPATH : {
-             "length" : LENGTH,
-             "hashes" : HASHES,
-             ("custom" : CUSTOM) }
-         , ...
-       }
-
-   Each key of the TARGETS object is a TARGETPATH.  A TARGETPATH is a path to
-   a file that is relative to a mirror's base URL of targets. To avoid
-   surprising behavior when resolving paths, it is RECOMMENDED that a
-   TARGETPATH uses the forward slash (/) as directory separator and does not
-   start with a directory separator. The recommendation for TARGETPATH aligns
-   with the ["path-relative-URL string"
-   definition](https://url.spec.whatwg.org/#path-relative-url-string) in the
-   WHATWG URL specification.
-
-   It is allowed to have a TARGETS object with no TARGETPATH elements.  This
-   can be used to indicate that no target files are available.
-
-   LENGTH is the integer length in bytes of the target file at TARGETPATH.
-
-   HASHES is a dictionary that specifies one or more hashes, including the
-   cryptographic hash function.  For example: { "sha256": HASH, ... }. HASH is
-   the hexdigest of the cryptographic function computed on the target file.
-
-   If defined, the elements and values of the CUSTOM object will be made
-   available to the client application.  The format of the CUSTOM object is
-   opaque to the framework, which only needs to know that the "custom"
-   attribute maps to an object.  The CUSTOM object may include version
-   numbers, dependencies, requirements, or any other data that the application
-   wants to include to describe the file at TARGETPATH.  The application may
-   use this information to guide download decisions.
-
-   DELEGATIONS is an object whose format is the following:
-
-       { "keys" : {
-             KEYID : KEY,
-             ... },
-         "roles" : [{
-             "name": ROLENAME,
-             "keyids" : [ KEYID, ... ] ,
-             "threshold" : THRESHOLD,
-             ("path_hash_prefixes" : [ HEX_DIGEST, ... ] |
-              "paths" : [ PATHPATTERN, ... ]),
-             "terminating": TERMINATING,
-         }, ... ]
-       }
-
-   "keys" lists the public keys to verify signatures of delegated targets roles.
-   Revocation and replacement of delegated targets roles keys is done by
-   changing the keys in this field in the delegating role's metadata.
-
-   ROLENAME is the name of the delegated role.  For example,
-   "projects".
-
-   TERMINATING is a boolean indicating whether subsequent delegations should be
-   considered.
-
-   As explained in the [Diplomat
-   paper](https://github.com/theupdateframework/tuf/blob/develop/docs/papers/protect-community-repositories-nsdi2016.pdf),
-   terminating delegations instruct the client not to consider future trust
-   statements that match the delegation's pattern, which stops the delegation
-   processing once this delegation (and its descendants) have been processed.
-   A terminating delegation for a package causes any further statements about a
-   package that are not made by the delegated party or its descendants to be
-   ignored.
-
-   In order to discuss target paths, a role MUST specify only one of the
-   "path_hash_prefixes" or "paths" attributes, each of which we discuss next.
-
-   The "path_hash_prefixes" list is used to succinctly describe a set of target
-   paths. Specifically, each HEX_DIGEST in "path_hash_prefixes" describes a set
-   of target paths; therefore, "path_hash_prefixes" is the union over each
-   prefix of its set of target paths. The target paths must meet this
-   condition: each target path, when hashed with the SHA-256 hash function to
-   produce a 64-byte hexadecimal digest (HEX_DIGEST), must share the same
-   prefix as one of the prefixes in "path_hash_prefixes". This is useful to
-   split a large number of targets into separate bins identified by consistent
-   hashing.
-
-   The "paths" list describes paths that the role is trusted to provide.
-   Clients MUST check that a target is in one of the trusted paths of all roles
-   in a delegation chain, not just in a trusted path of the role that describes
-   the target file.  PATHPATTERN can include shell-style wildcards and supports
-   the Unix filename pattern matching convention.  Its format may either
-   indicate a path to a single file, or to multiple paths with the use of
-   shell-style wildcards.  For example, the path pattern "targets/*.tgz" would
-   match file paths "targets/foo.tgz" and "targets/bar.tgz", but not
-   "targets/foo.txt".  Likewise, path pattern "foo-version-?.tgz" matches
-   "foo-version-2.tgz" and "foo-version-a.tgz", but not "foo-version-alpha.tgz".
-   To avoid surprising behavior when matching targets with PATHPATTERN, it is
-   RECOMMENDED that PATHPATTERN uses the forward slash (/) as directory
-   separator and does not start with a directory separator, akin to
-   TARGETSPATH.
-
-
-   Prioritized delegations allow clients to resolve conflicts between delegated
-   roles that share responsibility for overlapping target paths.  To resolve
-   conflicts, clients must consider metadata in order of appearance of delegations;
-   we treat the order of delegations such that the first delegation is trusted
-   over the second one, the second delegation is trusted more than the third
-   one, and so on. Likewise, the metadata of the first delegation will override that
-   of the second delegation, the metadata of the second delegation will override
-   that of the third one, etc. In order to accommodate prioritized
-   delegations, the "roles" key in the DELEGATIONS object above points to an array
-   of delegated roles, rather than to a hash table.
-
-   The metadata files for delegated target roles has the same format as the
-   top-level targets.json metadata file.
-
-   A targets.json example file:
-
-       {
-       "signatures": [
-        {
-         "keyid": "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164",
-         "sig": "e9fd40008fba263758a3ff1dc59f93e42a4910a282749af915fbbea1401178e5a0
-                 12090c228f06db1deb75ad8ddd7e40635ac51d4b04301fce0fd720074e0209"
-        }
-       ],
-       "signed": {
-        "_type": "targets",
-        "spec_version": "1.0.0",
-        "delegations": {
-         "keys": {
-          "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6": {
-           "keytype": "ed25519",
-           "scheme": "ed25519",
-           "keyval": {
-            "public": "b6e40fb71a6041212a3d84331336ecaa1f48a0c523f80ccc762a034c727606fa"
-           }
-          }
-         },
-         "roles": [
-          {
-           "keyids": [
-            "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6"
-           ],
-           "name": "project",
-           "paths": [
-            "project/file3.txt"
-           ],
-           "threshold": 1
-          }
-         ]
-        },
-        "expires": "2030-01-01T00:00:00Z",
-        "targets": {
-         "file1.txt": {
-          "hashes": {
-           "sha256": "65b8c67f51c993d898250f40aa57a317d854900b3a04895464313e48785440da"
-          },
-          "length": 31
-         },
-         "dir/file2.txt": {
-          "hashes": {
-           "sha256": "452ce8308500d83ef44248d8e6062359211992fd837ea9e370e561efb1a4ca99"
-          },
-          "length": 39
-         }
-        },
-        "version": 1
-        }
-       }
-
-* **4.6. File formats: timestamp.json**
-
-   The timestamp file is signed by a timestamp key.  It indicates the latest
-   version of the snapshot metadata and is frequently re-signed to limit the
-   amount of time a client can be kept unaware of interference with obtaining
-   updates.
-
-   Timestamp files will potentially be downloaded very frequently.  Unnecessary
-   information in them will be avoided.
-
-   The "signed" portion of timestamp.json is as follows:
-
-       { "_type" : "timestamp",
-         "spec_version" : SPEC_VERSION,
-         "version" : VERSION,
-         "expires" : EXPIRES,
-         "meta" : METAFILES
-       }
-
-   SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
-
-   METAFILES is the same as described for the snapshot.json file.  In the case
-   of the timestamp.json file, this MUST only include a description of the
-   snapshot.json file.
-
-   A signed timestamp.json example file:
-
-       {
-       "signatures": [
-        {
-         "keyid": "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3",
-         "sig": "90d2a06c7a6c2a6a93a9f5771eb2e5ce0c93dd580bebc2080d10894623cfd6eaed
-                 f4df84891d5aa37ace3ae3736a698e082e12c300dfe5aee92ea33a8f461f02"
-        }
-       ],
-       "signed": {
-        "_type": "timestamp",
-        "spec_version": "1.0.0",
-        "expires": "2030-01-01T00:00:00Z",
-        "meta": {
-         "snapshot.json": {
-          "hashes": {
-           "sha256": "c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681"
-          },
-          "length": 1007,
-          "version": 1
-         }
-        },
-        "version": 1
-        }
-       }
-
-* **4.7. File formats: mirrors.json**
-
-   The mirrors.json file is signed by the mirrors role.  It indicates which
-   mirrors are active and believed to be mirroring specific parts of the
-   repository.
-
-   The "signed" portion of mirrors.json is as follows:
-
-
-      { "_type" : "mirrors",
-       "spec_version" : SPEC_VERSION,
-       "version" : VERSION,
-       "expires" : EXPIRES,
-       "mirrors" : [
-          { "urlbase" : URLBASE,
-            "metapath" : METAPATH,
-            "targetspath" : TARGETSPATH,
-            "metacontent" : [ PATHPATTERN ... ] ,
-            "targetscontent" : [ PATHPATTERN ... ] ,
-            ("custom" : { ... }) }
-          , ... ]
+        "name": "project",
+        "paths": [
+        "project/file3.txt"
+        ],
+        "threshold": 1
       }
+      ]
+    },
+    "expires": "2030-01-01T00:00:00Z",
+    "targets": {
+      "file1.txt": {
+      "hashes": {
+        "sha256": "65b8c67f51c993d898250f40aa57a317d854900b3a04895464313e48785440da"
+      },
+      "length": 31
+      },
+      "dir/file2.txt": {
+      "hashes": {
+        "sha256": "452ce8308500d83ef44248d8e6062359211992fd837ea9e370e561efb1a4ca99"
+      },
+      "length": 39
+      }
+    },
+    "version": 1
+    }
+    }
 
-   URLBASE is the URL of the mirror which METAPATH and TARGETSPATH are relative
-   to.  All metadata files will be retrieved from METAPATH and all target files
-   will be retrieved from TARGETSPATH.
+## File formats: timestamp.json ## {#file-formats-timestamp}
 
-   The lists of PATHPATTERN for "metacontent" and "targetscontent" describe the
-   metadata files and target files available from the mirror.
+The timestamp file is signed by a timestamp key.  It indicates the latest
+version of the snapshot metadata and is frequently re-signed to limit the
+amount of time a client can be kept unaware of interference with obtaining
+updates.
 
-   The order of the list of mirrors is important.  For any file to be
-   downloaded, whether it is a metadata file or a target file, the framework on
-   the client will give priority to the mirrors that are listed first.  That is,
-   the first mirror in the list whose "metacontent" or "targetscontent" include
-   a path that indicate the desired file can be found there will the first
-   mirror that will be used to download that file.  Successive mirrors with
-   matching paths will only be tried if downloading from earlier mirrors fails.
-   This behavior can be modified by the client code that uses the framework to,
-   for example, randomly select from the listed mirrors.
+Timestamp files will potentially be downloaded very frequently.  Unnecessary
+information in them will be avoided.
 
-## **5. Detailed workflows**
+The "signed" portion of timestamp.json is as follows:
 
-### **The client application**
+    { "_type" : "timestamp",
+      "spec_version" : SPEC_VERSION,
+      "version" : VERSION,
+      "expires" : EXPIRES,
+      "meta" : METAFILES
+    }
 
-  Note: If a step in the following workflow does not succeed (e.g., the update
-  is aborted because a new metadata file was not signed), the client should
-  still be able to update again in the future. Errors raised during the update
-  process should not leave clients in an unrecoverable state.
+SPEC_VERSION, VERSION and EXPIRES are the same as is described for the root.json file.
 
-  **5.0**. **Record the time at which the update began** as the fixed update
-  start time.  Time is fixed at the beginning of the update workflow to allow
-  an application using TUF to effectively pause time, in order to ensure that
-  metadata which has a valid expiration time at the beginning of an update
-  does not fail an expiration check later in the update workflow.
+METAFILES is the same as described for the snapshot.json file.  In the case
+of the timestamp.json file, this MUST only include a description of the
+snapshot.json file.
 
-  **5.1**. **Load the trusted root metadata file.** We assume that a good,
-  trusted copy of this file was shipped with the package manager or software
-  updater using an out-of-band process.  Note that the expiration of the
-  trusted root metadata file does not matter, because we will attempt to update
-  it in the next step.
+A signed timestamp.json example file:
 
-  **5.2**. **Update the root metadata file.** Since it may now be signed using
+    {
+    "signatures": [
+    {
+      "keyid": "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3",
+      "sig": "90d2a06c7a6c2a6a93a9f5771eb2e5ce0c93dd580bebc2080d10894623cfd6eaed
+              f4df84891d5aa37ace3ae3736a698e082e12c300dfe5aee92ea33a8f461f02"
+    }
+    ],
+    "signed": {
+    "_type": "timestamp",
+    "spec_version": "1.0.0",
+    "expires": "2030-01-01T00:00:00Z",
+    "meta": {
+      "snapshot.json": {
+      "hashes": {
+        "sha256": "c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681"
+      },
+      "length": 1007,
+      "version": 1
+      }
+    },
+    "version": 1
+    }
+    }
+
+## File formats: mirrors.json ## {#file-formats-mirrors}
+
+The mirrors.json file is signed by the mirrors role.  It indicates which
+mirrors are active and believed to be mirroring specific parts of the
+repository.
+
+The "signed" portion of mirrors.json is as follows:
+
+
+  { "_type" : "mirrors",
+    "spec_version" : SPEC_VERSION,
+    "version" : VERSION,
+    "expires" : EXPIRES,
+    "mirrors" : [
+      { "urlbase" : URLBASE,
+        "metapath" : METAPATH,
+        "targetspath" : TARGETSPATH,
+        "metacontent" : [ PATHPATTERN ... ] ,
+        "targetscontent" : [ PATHPATTERN ... ] ,
+        ("custom" : { ... }) }
+      , ... ]
+  }
+
+URLBASE is the URL of the mirror which METAPATH and TARGETSPATH are relative
+to.  All metadata files will be retrieved from METAPATH and all target files
+will be retrieved from TARGETSPATH.
+
+The lists of PATHPATTERN for "metacontent" and "targetscontent" describe the
+metadata files and target files available from the mirror.
+
+The order of the list of mirrors is important.  For any file to be
+downloaded, whether it is a metadata file or a target file, the framework on
+the client will give priority to the mirrors that are listed first.  That is,
+the first mirror in the list whose "metacontent" or "targetscontent" include
+a path that indicate the desired file can be found there will the first
+mirror that will be used to download that file.  Successive mirrors with
+matching paths will only be tried if downloading from earlier mirrors fails.
+This behavior can be modified by the client code that uses the framework to,
+for example, randomly select from the listed mirrors.
+
+# Detailed workflows # {#detailed-workflows}
+
+## The client application ## {#the-client-application}
+
+Note: If a step in the following workflow does not succeed (e.g., the update
+is aborted because a new metadata file was not signed), the client should
+still be able to update again in the future. Errors raised during the update
+process should not leave clients in an unrecoverable state.
+
+## Record the time at which the update began ## {#fix-time}
+
+Record the time at which the update began as the fixed update start time.
+Time is fixed at the beginning of the update workflow to allow
+an application using TUF to effectively pause time, in order to ensure that
+metadata which has a valid expiration time at the beginning of an update
+does not fail an expiration check later in the update workflow.
+
+## Load the trusted root metadata file ## {#load-trusted-root}
+
+Load the trusted root metadata file.  We assume that a good,
+trusted copy of this file was shipped with the package manager or software
+updater using an out-of-band process.  Note that the expiration of the
+trusted root metadata file does not matter, because we will attempt to update
+it in the next step.
+
+## Update the root role ## {#update-root}
+
+1. Since it may now be signed using
   entirely different keys, the client MUST somehow be able to establish a
   trusted line of continuity to the latest set of keys (see Section 6.1). To do
   so, the client MUST download intermediate root metadata files, until the
@@ -1111,10 +1118,10 @@ repo](https://github.com/theupdateframework/specification/issues).
   consistent snapshots in order to download _versioned_ root metadata files as
   described next.
 
-  * **5.2.1**. Let N denote the version number of the trusted root metadata
+1. Let N denote the version number of the trusted root metadata
   file.
 
-  * **5.2.2**. **Try downloading version N+1 of the root metadata file**, up to
+1. **Try downloading version N+1 of the root metadata file**, up to
   some W number of bytes (because the size is unknown). The value for W is set
   by the authors of the application using TUF. For example, W may be tens of
   kilobytes. The filename used to download the root metadata file is of the
@@ -1124,7 +1131,7 @@ repo](https://github.com/theupdateframework/specification/issues).
   The value for Y is set by the authors of the application using TUF. For
   example, Y may be 2^10.
 
-  * **5.2.3. Check for an arbitrary software attack.** Version N+1 of the root
+1. **Check for an arbitrary software attack.** Version N+1 of the root
   metadata file MUST have been signed by: (1) a threshold of keys specified in
   the trusted root metadata file (version N), and (2) a threshold of keys
   specified in the new root metadata file being validated (version N+1).  If
@@ -1132,7 +1139,7 @@ repo](https://github.com/theupdateframework/specification/issues).
   and report the signature failure.  On the next update cycle, begin at step
   5.1 and version N of the root metadata file.
 
-  * **5.2.4. Check for a rollback attack.** The version number of the trusted
+1. **Check for a rollback attack.** The version number of the trusted
   root metadata file (version N) MUST be less than or equal to the version
   number of the new root metadata file (version N+1). Effectively, this means
   checking that the version number signed in the new root metadata file is
@@ -1141,25 +1148,25 @@ repo](https://github.com/theupdateframework/specification/issues).
   rollback attack.  On the next update cycle, begin at step 5.1 and version N
   of the root metadata file.
 
-  * **5.2.5**. Note that the expiration of the new (intermediate) root metadata
+1. Note that the expiration of the new (intermediate) root metadata
   file does not matter yet, because we will check for it in step 5.2.9.
 
-  * **5.2.6**. **Set the trusted root metadata file** to the new root metadata
+1. **Set the trusted root metadata file** to the new root metadata
   file.
 
-  * **5.2.7**. **Persist root metadata.** The client MUST write the file to
+1. **Persist root metadata.** The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. root.json).
 
-  * **5.2.8**. **Repeat steps 5.2.1 to 5.2.8**.
+1. Repeat steps 5.2.1 to 5.2.8
 
-  * **5.2.9**. **Check for a freeze attack.** The expiration timestamp in the
+1. **Check for a freeze attack.** The expiration timestamp in the
   trusted root metadata file MUST be higher than the fixed update start time.
   If the trusted root metadata file has expired, abort the update cycle,
   report the potential freeze attack.  On the next update cycle, begin at step
   5.1 and version N of the root metadata file.
 
-  * **5.2.10**. **If the timestamp and / or snapshot keys have been rotated,
-  then delete the trusted timestamp and snapshot metadata files.** This is done
+1. **If the timestamp and / or snapshot keys have been rotated, then delete the
+  trusted timestamp and snapshot metadata files.** This is done
   in order to recover from fast-forward attacks after the repository has been
   compromised and recovered. A _fast-forward attack_ happens when attackers
   arbitrarily increase the version numbers of: (1) the timestamp metadata, (2)
@@ -1168,72 +1175,76 @@ repo](https://github.com/theupdateframework/specification/issues).
   paper](https://ssl.engineering.nyu.edu/papers/kuppusamy-mercury-usenix-2017.pdf)
   for more details.
 
-  * **5.2.11**. **Set whether consistent snapshots are used as per the trusted
-  root metadata file** (see Section 4.3).
+1. **Set whether consistent snapshots are used as per the trusted**
+    root metadata file (see Section 4.3).
 
-**5.3**. **Download the timestamp metadata file**, up to X number of bytes
-(because the size is unknown). The value for X is set by the authors of the
-application using TUF. For example, X may be tens of kilobytes. The filename
-used to download the timestamp metadata file is of the fixed form FILENAME.EXT
-(e.g., timestamp.json).
+## Update the timestamp role ## {#update-timestamp}
 
-  * **5.3.1**. **Check for an arbitrary software attack.** The new timestamp
+1. **Download the timestamp metadata file**, up to X number of bytes
+  (because the size is unknown). The value for X is set by the authors of the
+  application using TUF. For example, X may be tens of kilobytes. The filename
+  used to download the timestamp metadata file is of the fixed form FILENAME.EXT
+  (e.g., timestamp.json).
+
+1. **Check for an arbitrary software attack.** The new timestamp
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new timestamp metadata file is not
   properly signed, discard it, abort the update cycle, and report the signature
   failure.
 
-  * **5.3.2**. **Check for a rollback attack.**
+1. **Check for a rollback attack.**
 
-    * **5.3.2.1**. The version number of the trusted timestamp metadata file, if
+  1. The version number of the trusted timestamp metadata file, if
     any, MUST be less than or equal to the version number of the new timestamp
     metadata file.  If the new timestamp metadata file is older than the
     trusted timestamp metadata file, discard it, abort the update cycle, and
     report the potential rollback attack.
 
-    * **5.3.2.2**. The version number of the snapshot metadata file in the
+  1. The version number of the snapshot metadata file in the
     trusted timestamp metadata file, if any, MUST be less than or equal to its
     version number in the new timestamp metadata file.  If not, discard the new
     timestamp metadata file, abort the update cycle, and report the failure.
 
-  * **5.3.3**. **Check for a freeze attack.** The expiration timestamp in the
+1. **Check for a freeze attack.** The expiration timestamp in the
   new timestamp metadata file MUST be higher than the fixed update start time.
   If so, the new timestamp metadata file becomes the trusted timestamp
   metadata file.  If the new timestamp metadata file has expired, discard it,
   abort the update cycle, and report the potential freeze attack.
 
-  * **5.3.4**. **Persist timestamp metadata.** The client MUST write the file
+1. **Persist timestamp metadata**. The client MUST write the file
   to non-volatile storage as FILENAME.EXT (e.g. timestamp.json).
 
-**5.4**. **Download snapshot metadata file**, up to either the number of bytes
-specified in the timestamp metadata file, or some Y number of bytes. The value
-for Y is set by the authors of the application using TUF. For example, Y may be
-tens of kilobytes. If consistent snapshots are not used (see
-Section 7), then the filename used to download the snapshot metadata file is of
-the fixed form FILENAME.EXT (e.g., snapshot.json).  Otherwise, the filename is
-of the form VERSION_NUMBER.FILENAME.EXT (e.g., 42.snapshot.json), where
-VERSION_NUMBER is the version number of the snapshot metadata file listed in
-the timestamp metadata file.
+## Update the snapshot role ## {#update-snapshot}
 
-  * **5.4.1**. **Check against timestamp role's snapshot hash.** The hashes
+1. **Download snapshot metadata file** , up to either the number of bytes
+  specified in the timestamp metadata file, or some Y number of bytes. The value
+  for Y is set by the authors of the application using TUF. For example, Y may be
+  tens of kilobytes. If consistent snapshots are not used (see
+  Section 7), then the filename used to download the snapshot metadata file is of
+  the fixed form FILENAME.EXT (e.g., snapshot.json).  Otherwise, the filename is
+  of the form VERSION_NUMBER.FILENAME.EXT (e.g., 42.snapshot.json), where
+  VERSION_NUMBER is the version number of the snapshot metadata file listed in
+  the timestamp metadata file.
+
+1. **Check against timestamp role's snapshot hash**. The hashes
   of the new snapshot metadata file MUST match the hashes, if any, listed in
   the trusted timestamp metadata.  This is done, in part, to prevent a
   mix-and-match attack by man-in-the-middle attackers.  If the hashes do not
   match, discard the new snapshot metadata, abort the update cycle, and report
   the failure.
 
-  * **5.4.2**. **Check for an arbitrary software attack.** The new snapshot
+1. **Check for an arbitrary software attack**. The new snapshot
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new snapshot metadata file is not signed
   as required, discard it, abort the update cycle, and report the signature
   failure.
 
-  * **5.4.3**. **Check against timestamp role's snapshot version.** The version
+1. **Check against timestamp role's snapshot version**. The version
   number of the new snapshot metadata file MUST match the version number listed
   in the trusted timestamp metadata.  If the versions do not match, discard the
   new snapshot metadata, abort the update cycle, and report the failure.
 
-  * **5.4.4**. **Check for a rollback attack.** The version number of the targets
+1. **Check for a rollback attack**. The version number of the targets
   metadata file, and all delegated targets metadata files, if any, in the
   trusted snapshot metadata file, if any, MUST be less than or equal to its
   version number in the new snapshot metadata file. Furthermore, any targets
@@ -1242,219 +1253,223 @@ the timestamp metadata file.
   these conditions are not met, discard the new snapshot metadata file, abort
   the update cycle, and report the failure.
 
-  * **5.4.5**. **Check for a freeze attack.** The expiration timestamp in the
+1. **Check for a freeze attack**. The expiration timestamp in the
   new snapshot metadata file MUST be higher than the fixed update start time.
   If so, the new snapshot metadata file becomes the trusted snapshot metadata
   file.  If the new snapshot metadata file is expired, discard it, abort the
   update cycle, and report the potential freeze attack.
 
 
-  * **5.4.6**. **Persist snapshot metadata.** The client MUST write the file to
+1. **Persist snapshot metadata**. The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. snapshot.json).
 
-**5.5**. **Download the top-level targets metadata file**, up to either the
-number of bytes specified in the snapshot metadata file, or some Z number of
-bytes. The value for Z is set by the authors of the application using TUF. For
-example, Z may be tens of kilobytes.  If consistent snapshots are not used (see
-Section 7), then the filename used to download the targets metadata file is of
-the fixed form FILENAME.EXT (e.g., targets.json).  Otherwise, the filename is
-of the form VERSION_NUMBER.FILENAME.EXT (e.g., 42.targets.json), where
-VERSION_NUMBER is the version number of the targets metadata file listed in the
-snapshot metadata file.
+## Update the targets role ## {#update-targets}
 
-  * **5.5.1**. **Check against snapshot role's targets hash.** The hashes
+1. **Download the top-level targets metadata file**, up to either the
+  number of bytes specified in the snapshot metadata file, or some Z number of
+  bytes. The value for Z is set by the authors of the application using TUF. For
+  example, Z may be tens of kilobytes.  If consistent snapshots are not used (see
+  Section 7), then the filename used to download the targets metadata file is of
+  the fixed form FILENAME.EXT (e.g., targets.json).  Otherwise, the filename is
+  of the form VERSION_NUMBER.FILENAME.EXT (e.g., 42.targets.json), where
+  VERSION_NUMBER is the version number of the targets metadata file listed in the
+  snapshot metadata file.
+
+1. **Check against snapshot role's targets hash**. The hashes
   of the new targets metadata file MUST match the hashes, if any, listed in the
   trusted snapshot metadata.  This is done, in part, to prevent a mix-and-match
   attack by man-in-the-middle attackers.  If the new targets metadata file does
   not match, discard the new target metadata, abort the update cycle, and
   report the failure.
 
-  * **5.5.2**. **Check for an arbitrary software attack.** The new targets
+1. **Check for an arbitrary software attack**. The new targets
   metadata file MUST have been signed by a threshold of keys specified in the
   trusted root metadata file.  If the new targets metadata file is not signed
   as required, discard it, abort the update cycle, and report the failure.
 
-  * **5.5.3**. **Check against snapshot role's targets version.** The version
+1. **Check against snapshot role's targets version**. The version
   number of the new targets metadata file MUST match the version number listed
   in the trusted snapshot metadata.  If the versions do not match, discard it,
   abort the update cycle, and report the failure.
 
-  * **5.5.4**. **Check for a freeze attack.** The expiration timestamp in the
+1. **Check for a freeze attack**. The expiration timestamp in the
   new targets metadata file MUST be higher than the fixed update start time.
   If so, the new targets metadata file becomes the trusted targets metadata
   file.  If the new targets metadata file is expired, discard it, abort the
   update cycle, and report the potential freeze attack.
 
-  * **5.5.5**. **Persist targets metadata.** The client MUST write the file to
+1. **Persist targets metadata**. The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. targets.json).
 
-  * **5.5.6**. **Perform a pre-order depth-first search for metadata about the
-  desired target, beginning with the top-level targets role.**  Note: If
+1. **Perform a pre-order depth-first search for metadata about the
+  desired target, beginning with the top-level targets role.** Note: If
   any metadata requested in steps 5.5.6.1 - 5.5.6.2 cannot be downloaded nor
   validated, end the search and report that the target cannot be found.
 
-    * **5.5.6.1**. If this role has been visited before, then skip this role
-    (so that cycles in the delegation graph are avoided).  Otherwise, if an
-    application-specific maximum number of roles have been visited, then go to
-    step 5.6 (so that attackers cannot cause the client to waste excessive
-    bandwidth or time).  Otherwise, if this role contains metadata about the
-    desired target, then go to step 5.6.
+  1. If this role has been visited before, then skip this role
+     (so that cycles in the delegation graph are avoided).  Otherwise, if an
+     application-specific maximum number of roles have been visited, then go to
+     step 5.6 (so that attackers cannot cause the client to waste excessive
+     bandwidth or time).  Otherwise, if this role contains metadata about the
+     desired target, then go to step 5.6.
 
-    * **5.5.6.2**. Otherwise, recursively search the list of delegations in
-    order of appearance.
+  1. Otherwise, recursively search the list of delegations in
+     order of appearance.
 
-      * **5.5.6.2.1**. If the current delegation is a multi-role delegation,
-      recursively visit each role, and check that each has signed exactly the
-      same non-custom metadata (i.e., length and hashes) about the target (or
-      the lack of any such metadata).
+    1. If the current delegation is a multi-role delegation,
+       recursively visit each role, and check that each has signed exactly the
+       same non-custom metadata (i.e., length and hashes) about the target (or
+       the lack of any such metadata).
 
-      * **5.5.6.2.2**. If the current delegation is a terminating delegation,
-      then jump to step 5.6.
+    1. If the current delegation is a terminating delegation,
+       then jump to step 5.6.
 
-      * **5.5.6.2.3**. Otherwise, if the current delegation is a
-      non-terminating delegation, continue processing the next delegation, if
-      any. Stop the search, and jump to step 5.6 as soon as a delegation
-      returns a result.
+    1. Otherwise, if the current delegation is a
+       non-terminating delegation, continue processing the next delegation, if
+       any. Stop the search, and jump to step 5.6 as soon as a delegation
+       returns a result.
 
-**5.6**. **Verify the desired target against its targets metadata**.
+## Fetch target ## {#fetch-target}
 
-  * **5.6.1**. If there is no targets metadata about this target, abort the
-  update cycle and report that there is no such target.
+1. **Verify the desired target against its targets metadata**.
 
-  * **5.6.2**. Otherwise, download the target (up to the number of bytes
-  specified in the targets metadata), and verify that its hashes match the
-  targets metadata. (We download up to this number of bytes, because in some
-  cases, the exact number is unknown. This may happen, for example, if an
-  external program is used to compute the root hash of a tree of targets files,
-  and this program does not provide the total size of all of these files.) If
-  consistent snapshots are not used (see Section 7), then the filename used to
-  download the target file is of the fixed form FILENAME.EXT (e.g.,
-  foobar.tar.gz).  Otherwise, the filename is of the form HASH.FILENAME.EXT
-  (e.g.,
-  c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681.foobar.tar.gz),
-  where HASH is one of the hashes of the targets file listed in the targets
-  metadata file found earlier in step 5.5.  In either case, the client MUST write
-  the file to non-volatile storage as FILENAME.EXT.
+1. If there is no targets metadata about this target, abort the
+    update cycle and report that there is no such target.
 
-## **6. Usage**
+1. Otherwise, download the target (up to the number of bytes
+   specified in the targets metadata), and verify that its hashes match the
+   targets metadata. (We download up to this number of bytes, because in some
+   cases, the exact number is unknown. This may happen, for example, if an
+   external program is used to compute the root hash of a tree of targets files,
+   and this program does not provide the total size of all of these files.) If
+   consistent snapshots are not used (see Section 7), then the filename used to
+   download the target file is of the fixed form FILENAME.EXT (e.g.,
+   foobar.tar.gz).  Otherwise, the filename is of the form HASH.FILENAME.EXT
+   (e.g.,
+   c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681.foobar.tar.gz),
+   where HASH is one of the hashes of the targets file listed in the targets
+   metadata file found earlier in step 5.5.  In either case, the client MUST write
+   the file to non-volatile storage as FILENAME.EXT.
 
-   See https://theupdateframework.io/ for discussion of recommended usage
-   in various situations.
+# 6. Usage # {#usage}
 
-* **6.1. Key management and migration**
+See https://theupdateframework.io/ for discussion of recommended usage
+in various situations.
 
-   All keys, except those for the timestamp and mirrors roles, should be
-   stored securely offline (e.g. encrypted and on a separate machine, in
-   special-purpose hardware, etc.).  This document does not prescribe how keys
-   should be encrypted and stored, and so it is left to implementers of
-   this document to decide how best to secure them.
+## Key management and migration ## {#key-management-and-migration}
 
-   To replace a compromised root key or any other top-level role key, the root
-   role signs a new root.json file that lists the updated trusted keys for the
-   role.  When replacing root keys, an application will sign the new root.json
-   file with both the new and old root keys. Any time such a change is
-   required, the root.json file is versioned and accessible by version number,
-   e.g., 3.root.json.
+All keys, except those for the timestamp and mirrors roles, should be
+stored securely offline (e.g. encrypted and on a separate machine, in
+special-purpose hardware, etc.).  This document does not prescribe how keys
+should be encrypted and stored, and so it is left to implementers of
+this document to decide how best to secure them.
 
-   Clients that have outdated root keys can update to the latest set of trusted
-   root keys, by incrementally downloading all intermediate root metadata
-   files, and verifying that each current version of the root metadata is
-   signed by a threshold of keys specified by its immediate predecessor as well
-   as a threshold of keys specified by itself.
-   For example, if there is a 1.root.json that has threshold 2 and a
-   2.root.json that has threshold 3, 2.root.json MUST be signed by at least 2
-   keys defined in 1.root.json and at least 3 keys defined in 2.root.json. The
-   client starts the root key update process with the latest version of root
-   metadata available on the client, and stops when no version N+1 (where N is
-   the latest trusted version) of the root metadata is available from the
-   repository. This ensures that an outdated client can always correctly
-   re-trace the chain of trust across multiple root key updates, even if the
-   latest set of root keys on the client dates back multiple root metadata
-   versions. See step 5.2 of the client application workflow for more details.
+To replace a compromised root key or any other top-level role key, the root
+role signs a new root.json file that lists the updated trusted keys for the
+role.  When replacing root keys, an application will sign the new root.json
+file with both the new and old root keys. Any time such a change is
+required, the root.json file is versioned and accessible by version number,
+e.g., 3.root.json.
 
-   Note that an attacker, who controls the repository, can launch freeze
-   attacks by withholding new root metadata. The attacker does not need to
-   compromise root keys to do so. However, these freeze attacks are limited by
-   the expiration time of the latest root metadata available to the client.
+Clients that have outdated root keys can update to the latest set of trusted
+root keys, by incrementally downloading all intermediate root metadata
+files, and verifying that each current version of the root metadata is
+signed by a threshold of keys specified by its immediate predecessor as well
+as a threshold of keys specified by itself.
+For example, if there is a 1.root.json that has threshold 2 and a
+2.root.json that has threshold 3, 2.root.json MUST be signed by at least 2
+keys defined in 1.root.json and at least 3 keys defined in 2.root.json. The
+client starts the root key update process with the latest version of root
+metadata available on the client, and stops when no version N+1 (where N is
+the latest trusted version) of the root metadata is available from the
+repository. This ensures that an outdated client can always correctly
+re-trace the chain of trust across multiple root key updates, even if the
+latest set of root keys on the client dates back multiple root metadata
+versions. See step 5.2 of the client application workflow for more details.
 
-   To replace a delegated developer key, the role that delegated to that key
-   just replaces that key with another in the signed metadata where the
-   delegation is done.
+Note that an attacker, who controls the repository, can launch freeze
+attacks by withholding new root metadata. The attacker does not need to
+compromise root keys to do so. However, these freeze attacks are limited by
+the expiration time of the latest root metadata available to the client.
 
-## **7. Consistent snapshots**
+To replace a delegated developer key, the role that delegated to that key
+just replaces that key with another in the signed metadata where the
+delegation is done.
 
-   So far, we have considered a TUF repository that is relatively static (in
-   terms of how often metadata and target files are updated). The problem is
-   that if the repository (which may be a community repository such as PyPI,
-   RubyGems, CPAN, or SourceForge) is volatile, in the sense that the
-   repository is continually producing new TUF metadata as well as its targets,
-   then should clients read metadata while the same metadata is being written
-   to, they would effectively see denial-of-service attacks.  Therefore, the
-   repository needs to be careful about how it writes metadata and targets. The
-   high-level idea of the solution is that each snapshot will be contained in a
-   so-called consistent snapshot. If a client is reading from one consistent
-   snapshot, then the repository is free to write another consistent snapshot
-   without interrupting that client.
+# Consistent Snapshots # {#consistent-snapshots}
 
-* **7.1. Writing consistent snapshots**
+So far, we have considered a TUF repository that is relatively static (in
+terms of how often metadata and target files are updated). The problem is
+that if the repository (which may be a community repository such as PyPI,
+RubyGems, CPAN, or SourceForge) is volatile, in the sense that the
+repository is continually producing new TUF metadata as well as its targets,
+then should clients read metadata while the same metadata is being written
+to, they would effectively see denial-of-service attacks.  Therefore, the
+repository needs to be careful about how it writes metadata and targets. The
+high-level idea of the solution is that each snapshot will be contained in a
+so-called consistent snapshot. If a client is reading from one consistent
+snapshot, then the repository is free to write another consistent snapshot
+without interrupting that client.
 
-    We now explain how a repository should write metadata and targets to
-    produce self-contained consistent snapshots.
+## Writing consistent snapshots ## {#writing-consistent-snapshots}
 
-    Simply put, TUF should write every metadata file as such: if the
-    file had the original name of filename.ext, then it should be written to
-    non-volatile storage as version_number.filename.ext, where version_number
-    is an integer.
+We now explain how a repository should write metadata and targets to
+produce self-contained consistent snapshots.
 
-    On the other hand, consistent target files should be written to
-    non-volatile storage as digest.filename.ext.  This means that if the
-    referrer metadata lists N cryptographic hashes of the referred file, then
-    there must be N identical copies of the referred file, where each file will
-    be distinguished only by the value of the digest in its filename. The
-    modified filename need not include the name of the cryptographic hash
-    function used to produce the digest because, on a read, the choice of
-    function follows from the selection of a digest (which includes the name of
-    the cryptographic function) from all digests in the referred file.
+Simply put, TUF should write every metadata file as such: if the
+file had the original name of filename.ext, then it should be written to
+non-volatile storage as version_number.filename.ext, where version_number
+is an integer.
 
-    Additionally, the timestamp metadata (timestamp.json) should also be
-    written to non-volatile storage whenever it is updated. It is OPTIONAL for
-    an implementation to write identical copies at
-    version_number.timestamp.json for record-keeping purposes, because a
-    cryptographic hash of the timestamp metadata is usually not known in
-    advance. The same step applies to the root metadata (root.json), although
-    an implementation must write both root.json and version_number.root.json
-    because it is possible to download root metadata both with and without
-    known version numbers. These steps are required because these are the only
-    metadata files that may be requested without known version numbers.
+On the other hand, consistent target files should be written to
+non-volatile storage as digest.filename.ext.  This means that if the
+referrer metadata lists N cryptographic hashes of the referred file, then
+there must be N identical copies of the referred file, where each file will
+be distinguished only by the value of the digest in its filename. The
+modified filename need not include the name of the cryptographic hash
+function used to produce the digest because, on a read, the choice of
+function follows from the selection of a digest (which includes the name of
+the cryptographic function) from all digests in the referred file.
 
-    Most importantly, no metadata file format must be updated to refer to the
-    names of metadata or target files with their version numbers included. In
-    other words, if a metadata file A refers to another metadata file B as
-    filename.ext, then the filename must remain as filename.ext and not
-    version_number.filename.ext. This rule is in place so that metadata signed
-    by roles with offline keys will not be forced to sign for the metadata file
-    whenever it is updated. In the next subsection, we will see how clients
-    will reproduce the name of the intended file.
+Additionally, the timestamp metadata (timestamp.json) should also be
+written to non-volatile storage whenever it is updated. It is OPTIONAL for
+an implementation to write identical copies at
+version_number.timestamp.json for record-keeping purposes, because a
+cryptographic hash of the timestamp metadata is usually not known in
+advance. The same step applies to the root metadata (root.json), although
+an implementation must write both root.json and version_number.root.json
+because it is possible to download root metadata both with and without
+known version numbers. These steps are required because these are the only
+metadata files that may be requested without known version numbers.
 
-    Finally, the root metadata should write the Boolean "consistent_snapshot"
-    attribute at the root level of its keys of attributes. If consistent
-    snapshots are not written by the repository, then the attribute may either
-    be left unspecified or be set to the False value.  Otherwise, it must be
-    set to the True value.
+Most importantly, no metadata file format must be updated to refer to the
+names of metadata or target files with their version numbers included. In
+other words, if a metadata file A refers to another metadata file B as
+filename.ext, then the filename must remain as filename.ext and not
+version_number.filename.ext. This rule is in place so that metadata signed
+by roles with offline keys will not be forced to sign for the metadata file
+whenever it is updated. In the next subsection, we will see how clients
+will reproduce the name of the intended file.
 
-    Regardless of whether consistent snapshots are ever used or not, all
-    released versions of root metadata files should always be provided
-    so that outdated clients can update to the latest available root.
+Finally, the root metadata should write the Boolean "consistent_snapshot"
+attribute at the root level of its keys of attributes. If consistent
+snapshots are not written by the repository, then the attribute may either
+be left unspecified or be set to the False value.  Otherwise, it must be
+set to the True value.
+
+Regardless of whether consistent snapshots are ever used or not, all
+released versions of root metadata files should always be provided
+so that outdated clients can update to the latest available root.
 
 
-* **7.2. Reading consistent snapshots**
+## Reading consistent snapshots ## {#reading-consistent-snapshots}
 
-    See section 5 (The client application) for more details.
+See section 5 (The client application) for more details.
 
-## **F. Future directions and open questions**
+# Future directions and open questions # {#future-directions-and-open-questions}
 
-* **F.1. Support for bogus clocks.**
+## Support for bogus clocks ## {#support-for-bogus-clocks}
 
-   The framework may need to offer an application-enablable "no, my clock is
-   _supposed_ to be wrong" mode, since others have noticed that many users seem
-   to have incorrect clocks.
+The framework may need to offer an application-enablable "no, my clock is
+*supposed* to be wrong" mode, since others have noticed that many users seem
+to have incorrect clocks.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -671,7 +671,7 @@ The "signed" portion of <a>root.json</a> is as follows:
         ...
       ] ,
       "threshold" : <a>THRESHOLD</a>
-      },
+    },
     ...
   }
 }
@@ -731,74 +731,74 @@ A <a>root.json</a> example file:
 <pre highlight="json">
 {
   "signatures": [
-  {
-    "keyid": "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4",
-    "sig": "a312b9c3cb4a1b693e8ebac5ee1ca9cc01f2661c14391917dcb111517f72370809
-            f32c890c6b801e30158ac4efe0d4d87317223077784c7a378834249d048306"
-  }
+    {
+      "keyid": "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4",
+      "sig": "a312b9c3cb4a1b693e8ebac5ee1ca9cc01f2661c14391917dcb111517f72370809
+              f32c890c6b801e30158ac4efe0d4d87317223077784c7a378834249d048306"
+    }
   ],
   "signed": {
-  "_type": "root",
-  "spec_version": "1.0.0",
-  "consistent_snapshot": false,
-  "expires": "2030-01-01T00:00:00Z",
-  "keys": {
-    "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3": {
-    "keytype": "ed25519",
-    "scheme": "ed25519",
-    "keyval": {
-      "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"
-    }
+    "_type": "root",
+    "spec_version": "1.0.0",
+    "consistent_snapshot": false,
+    "expires": "2030-01-01T00:00:00Z",
+    "keys": {
+      "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3": {
+        "keytype": "ed25519",
+        "scheme": "ed25519",
+        "keyval": {
+          "public": "72378e5bc588793e58f81c8533da64a2e8f1565c1fcc7f253496394ffc52542c"
+        }
+      },
+      "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164": {
+        "keytype": "ed25519",
+        "scheme": "ed25519",
+        "keyval": {
+          "public": "68ead6e54a43f8f36f9717b10669d1ef0ebb38cee6b05317669341309f1069cb"
+        }
+      },
+      "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4": {
+        "keytype": "ed25519",
+        "scheme": "ed25519",
+        "keyval": {
+          "public": "66dd78c5c2a78abc6fc6b267ff1a8017ba0e8bfc853dd97af351949bba021275"
+        }
+      },
+      "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc": {
+        "keytype": "ed25519",
+        "scheme": "ed25519",
+        "keyval": {
+          "public": "01c61f8dc7d77fcef973f4267927541e355e8ceda757e2c402818dad850f856e"
+        }
+      }
     },
-    "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164": {
-    "keytype": "ed25519",
-    "scheme": "ed25519",
-    "keyval": {
-      "public": "68ead6e54a43f8f36f9717b10669d1ef0ebb38cee6b05317669341309f1069cb"
-    }
+    "roles": {
+      "root": {
+        "keyids": [
+          "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
+        ],
+        "threshold": 1
+      }
     },
-    "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4": {
-    "keytype": "ed25519",
-    "scheme": "ed25519",
-    "keyval": {
-      "public": "66dd78c5c2a78abc6fc6b267ff1a8017ba0e8bfc853dd97af351949bba021275"
-    }
-    },
-    "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc": {
-    "keytype": "ed25519",
-    "scheme": "ed25519",
-    "keyval": {
-      "public": "01c61f8dc7d77fcef973f4267927541e355e8ceda757e2c402818dad850f856e"
-    }
-    }
-  },
-  "roles": {
-    "root": {
-    "keyids": [
-      "cb3fbd83df4ba2471a736b065650878280964a98843ec13b457a99b2a21cc3b4"
-    ],
-    "threshold": 1
-    },
-    "snapshot": {
-    "keyids": [
-      "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc"
-    ],
-    "threshold": 1
-    },
-    "targets": {
-    "keyids": [
-      "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164"
-    ],
-    "threshold": 1
-    },
-    "timestamp": {
-    "keyids": [
-      "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3"
-    ],
-    "threshold": 1
-    }
-  },
-  "version": 1
+    "version": 1
   }
 }
 </pre>
@@ -830,9 +830,9 @@ as is described for the <a>root.json</a> file.
 <pre highlight="json">
 {
   <a for="snapshot">METAPATH</a> : {
-      "version" : <a for="metapath">VERSION</a>,
-      ("length" : <a for="metapath">LENGTH</a>,)
-      ("hashes" : <a for="metapath">HASHES</a>)
+    "version" : <a for="metapath">VERSION</a>,
+    ("length" : <a for="metapath">LENGTH</a>,)
+    ("hashes" : <a for="metapath">HASHES</a>)
   },
   ...
 }
@@ -875,9 +875,9 @@ A <a>snapshot.json</a> example file:
 {
   "signatures": [
     {
-    "keyid": "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc",
-    "sig": "f7f03b13e3f4a78a23561419fc0dd741a637e49ee671251be9f8f3fceedfc112e4
-            4ee3aaff2278fad9164ab039118d4dc53f22f94900dae9a147aa4d35dcfc0f"
+      "keyid": "66676daa73bdfb4804b56070c8927ae491e2a6c2314f05b854dea94de8ff6bfc",
+      "sig": "f7f03b13e3f4a78a23561419fc0dd741a637e49ee671251be9f8f3fceedfc112e4
+              4ee3aaff2278fad9164ab039118d4dc53f22f94900dae9a147aa4d35dcfc0f"
     }
   ],
   "signed": {
@@ -885,22 +885,22 @@ A <a>snapshot.json</a> example file:
     "spec_version": "1.0.0",
     "expires": "2030-01-01T00:00:00Z",
     "meta": {
-    "targets.json": {
-      "version": 1
-    },
-    "project1.json": {
-      "version": 1,
-      "hashes": {
-      "sha256": "f592d072e1193688a686267e8e10d7257b4ebfcf28133350dae88362d82a0c8a"
+      "targets.json": {
+        "version": 1
+      },
+      "project1.json": {
+        "version": 1,
+        "hashes": {
+          "sha256": "f592d072e1193688a686267e8e10d7257b4ebfcf28133350dae88362d82a0c8a"
+        }
+      },
+      "project2.json": {
+        "version": 1,
+        "length": 604,
+        "hashes": {
+          "sha256": "1f812e378264c3085bb69ec5f6663ed21e5882bbece3c3f8a0e8479f205ffb91"
+        }
       }
-    },
-    "project2.json": {
-      "version": 1,
-      "length": 604,
-      "hashes": {
-      "sha256": "1f812e378264c3085bb69ec5f6663ed21e5882bbece3c3f8a0e8479f205ffb91"
-      }
-    }
     },
     "version": 1
   }
@@ -1076,58 +1076,58 @@ top-level <a>targets.json</a> metadata file.
 A <a>targets.json</a> example file:
 
 <pre highlight="json">
-  {
-    "signatures": [
-      {
-        "keyid": "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164",
-        "sig": "e9fd40008fba263758a3ff1dc59f93e42a4910a282749af915fbbea1401178e5a0
-                12090c228f06db1deb75ad8ddd7e40635ac51d4b04301fce0fd720074e0209"
-      }
-    ],
-    "signed": {
-      "_type": "targets",
-      "spec_version": "1.0.0",
-      "delegations": {
-        "keys": {
+{
+  "signatures": [
+    {
+      "keyid": "135c2f50e57ff11e744d234a62cebad8c38daf399604a7655661cc9199c69164",
+      "sig": "e9fd40008fba263758a3ff1dc59f93e42a4910a282749af915fbbea1401178e5a0
+              12090c228f06db1deb75ad8ddd7e40635ac51d4b04301fce0fd720074e0209"
+    }
+  ],
+  "signed": {
+    "_type": "targets",
+    "spec_version": "1.0.0",
+    "delegations": {
+      "keys": {
         "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6": {
           "keytype": "ed25519",
           "scheme": "ed25519",
           "keyval": {
-          "public": "b6e40fb71a6041212a3d84331336ecaa1f48a0c523f80ccc762a034c727606fa"
+            "public": "b6e40fb71a6041212a3d84331336ecaa1f48a0c523f80ccc762a034c727606fa"
           }
         }
-        },
-        "roles": [
+      },
+      "roles": [
         {
           "keyids": [
-          "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6"
+            "f761033eb880143c52358d941d987ca5577675090e2215e856ba0099bc0ce4f6"
           ],
           "name": "project",
           "paths": [
-          "project/file3.txt"
+            "project/file3.txt"
           ],
           "threshold": 1
         }
-        ]
-      },
-      "expires": "2030-01-01T00:00:00Z",
-      "targets": {
-        "file1.txt": {
+      ]
+    },
+    "expires": "2030-01-01T00:00:00Z",
+    "targets": {
+      "file1.txt": {
         "hashes": {
           "sha256": "65b8c67f51c993d898250f40aa57a317d854900b3a04895464313e48785440da"
         },
         "length": 31
-        },
-        "dir/file2.txt": {
+      },
+      "dir/file2.txt": {
         "hashes": {
           "sha256": "452ce8308500d83ef44248d8e6062359211992fd837ea9e370e561efb1a4ca99"
         },
         "length": 39
-        }
-      },
-      "version": 1
-    }
+      }
+    },
+    "version": 1
   }
+}
 </pre>
 </div>
 
@@ -1164,26 +1164,26 @@ A signed <a>timestamp.json</a> example file:
 <pre highlight="json">
 {
   "signatures": [
-  {
-    "keyid": "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3",
-    "sig": "90d2a06c7a6c2a6a93a9f5771eb2e5ce0c93dd580bebc2080d10894623cfd6eaed
-            f4df84891d5aa37ace3ae3736a698e082e12c300dfe5aee92ea33a8f461f02"
-  }
+    {
+      "keyid": "1bf1c6e3cdd3d3a8420b19199e27511999850f4b376c4547b2f32fba7e80fca3",
+      "sig": "90d2a06c7a6c2a6a93a9f5771eb2e5ce0c93dd580bebc2080d10894623cfd6eaed
+              f4df84891d5aa37ace3ae3736a698e082e12c300dfe5aee92ea33a8f461f02"
+    }
   ],
   "signed": {
-  "_type": "timestamp",
-  "spec_version": "1.0.0",
-  "expires": "2030-01-01T00:00:00Z",
-  "meta": {
-    "snapshot.json": {
-    "hashes": {
-      "sha256": "c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681"
+    "_type": "timestamp",
+    "spec_version": "1.0.0",
+    "expires": "2030-01-01T00:00:00Z",
+    "meta": {
+      "snapshot.json": {
+        "hashes": {
+          "sha256": "c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681"
+        },
+        "length": 1007,
+        "version": 1
+      }
     },
-    "length": 1007,
     "version": 1
-    }
-  },
-  "version": 1
   }
 }
 </pre>

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -19,12 +19,12 @@ Metadata Include: This version off, Abstract off
 Text Macro: VERSION 1.0.17
 </pre>
 
-We strive to make the specification easy to implement, so if you come across
-any inconsistencies or experience any difficulty, do let us know by sending an
-email to our [mailing
-list](https://groups.google.com/forum/?fromgroups#!forum/theupdateframework),
-or by reporting an issue in the [specification
-repo](https://github.com/theupdateframework/specification/issues).
+Note: We strive to make the specification easy to implement, so if you come
+across any inconsistencies or experience any difficulty, do let us know by
+sending an email to our [mailing list](
+  https://groups.google.com/forum/?fromgroups#!forum/theupdateframework),
+or by reporting an issue in the [specification repo](
+  https://github.com/theupdateframework/specification/issues).
 
 
 # Introduction # {#introduction}

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -528,11 +528,11 @@ where:
 
       : <dfn for="role">KEYID</dfn>
       ::
-        the identifier of the key signing the ROLE dictionary.
+        the identifier of the key signing the <a for="role">ROLE</a> dictionary.
 
       : <dfn>SIGNATURE</dfn>
       ::
-        a hex-encoded signature of the canonical form of the metadata for ROLE.
+        a hex-encoded signature of the canonical form of the metadata for <a for="role">ROLE</a>.
 
 
 All keys have the format:
@@ -594,7 +594,7 @@ The <dfn for="keytype">"rsa"</dfn> format is:
 
 <pre highlight="json">
 {
-  "keytype" : "rsa",
+  "keytype" : <a for="keytype">"rsa"</a>,
   "scheme" : <a for="scheme">"rsassa-pss-sha256"</a>,
   "keyval" : {
     "public" : <a for="keyval-rsa">PUBLIC</a>
@@ -612,7 +612,7 @@ The <dfn for="keytype">"ed25519"</dfn> format is:
 
 <pre highlight="json">
 {
-  "keytype" : "ed25519",
+  "keytype" : <a for="keytype">"ed25519"</a>,
   "scheme" : <a for="scheme">"ed25519"</a>,
   "keyval" : {
     "public" : <a for="keyval-ed25519">PUBLIC</a>
@@ -630,7 +630,7 @@ The <dfn for="keytype">"ecdsa-sha2-nistp256"</dfn> format is:
 
 <pre highlight="json">
 {
-  "keytype" : "ecdsa-sha2-nistp256",
+  "keytype" : <a for="keytype">"ecdsa-sha2-nistp256"</a>,
   "scheme" : <a for="scheme">"ecdsa-sha2-nistp256"</a>,
   "keyval" : {
     "public" : <a for="keyval-ecdsa">PUBLIC</a>
@@ -650,7 +650,7 @@ the canonical form of the key.
 Metadata <dfn>date-time</dfn> follows the ISO 8601 standard.  The expected
 format of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is
 always in UTC, and the "Z" time zone designator is attached to indicate a
-zero UTC offset.  An example date-time string is "1985-10-21T01:21:00Z".
+zero UTC offset.  An example <a>date-time</a> string is "1985-10-21T01:21:00Z".
 
 
 ## File formats: root.json ## {#file-formats-root}
@@ -855,7 +855,7 @@ where:
   : <dfn for="snapshot">METAPATH</dfn>
   ::
     A string giving the file path of the metadata on the repository relative to
-    the metadata base URL.  For snapshot.json, these are top-level targets
+    the metadata base URL.  For <a>snapshot.json</a>, these are top-level targets
     metadata and delegated targets metadata.
 
   : <dfn for="metapath">VERSION</dfn>
@@ -956,7 +956,7 @@ where:
 
   : <a for="targets-obj">TARGETS</a>
   ::
-    Each key of the TARGETS object is a <a>TARGETPATH</a>.
+    Each key of the <a for="targets-obj">TARGETS</a> object is a <a>TARGETPATH</a>.
 
   : <dfn>TARGETPATH</dfn>
   ::
@@ -998,16 +998,16 @@ where:
 <pre highlight="json">
 {
   "keys" : {
-      KEYID : KEY,
+      <a for="role">KEYID</a> : KEY,
       ...
   },
   "roles" : [
     {
       "name": <a>ROLENAME</a>,
-      "keyids" : [ KEYID, ... ] ,
+      "keyids" : [ <a for="role">KEYID</a>, ... ] ,
       "threshold" : <a>THRESHOLD</a>,
-      ("path_hash_prefixes" : [ HEX_DIGEST, ... ] |
-      "paths" : [ PATHPATTERN, ... ]),
+      (<a>"path_hash_prefixes"</a> : [ HEX_DIGEST, ... ] |
+      "<a>paths</a>" : [ <a>PATHPATTERN</a>, ... ]),
       "terminating": <a>TERMINATING</a>,
     },
     ...
@@ -1084,7 +1084,7 @@ over the second one, the second delegation is trusted more than the third
 one, and so on. Likewise, the metadata of the first delegation will override that
 of the second delegation, the metadata of the second delegation will override
 that of the third one, etc. In order to accommodate prioritized
-delegations, the "roles" key in the DELEGATIONS object above points to an array
+delegations, the "roles" key in the <a>DELEGATIONS</a> object above points to an array
 of delegated roles, rather than to a hash table.
 
 The metadata files for delegated target roles has the same format as the
@@ -1171,10 +1171,10 @@ The "signed" portion of <a>timestamp.json</a> is as follows:
 }
 </pre>
 
-<a>SPEC_VERSION</a>, <a for="role">VERSION</a> and <a>EXPIRES</a> are the same as is described for the root.json file.
+<a>SPEC_VERSION</a>, <a for="role">VERSION</a> and <a>EXPIRES</a> are the same as is described for the <a>root.json</a> file.
 
 <a>METAFILES</a> is the same as described for the <a>snapshot.json</a> file.  In the case
-of the timestamp.json file, this MUST only include a description of the
+of the <a>timestamp.json</a> file, this MUST only include a description of the
 <a>snapshot.json</a> file.
 
 <div class="example" id="example-timestamp.json">
@@ -1224,7 +1224,7 @@ The "signed" portion of <a>mirrors.json</a> is as follows:
   "mirrors" : [
     { "urlbase" : <a>URLBASE</a>,
       "metapath" : <a for="mirrors">METAPATH</a>,
-      "targetspath" : TARGETSPATH,
+      "targetspath" : <a>TARGETSPATH</a>,
       "metacontent" : [ <a>PATHPATTERN</a> ... ] ,
       "targetscontent" : [ <a>PATHPATTERN</a> ... ] ,
       ("custom" : { ... }) }
@@ -1335,13 +1335,13 @@ it in the next step.
 8. **Persist root metadata.** The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. root.json).
 
-9. Repeat steps 5.3.1 to 5.3.8
+9. Repeat steps 5.3.2 to 5.3.9
 
 10. **Check for a freeze attack.** The expiration timestamp in the
   trusted root metadata file MUST be higher than the fixed update start time.
   If the trusted root metadata file has expired, abort the update cycle,
   report the potential freeze attack.  On the next update cycle, begin at step
-  5.1 and version N of the root metadata file.
+ [[#update-root]] and version N of the root metadata file.
 
 11. **If the timestamp and / or snapshot keys have been rotated, then delete the
   trusted timestamp and snapshot metadata files.** This is done
@@ -1488,7 +1488,7 @@ it in the next step.
   1. If this role has been visited before, then skip this role
      (so that cycles in the delegation graph are avoided).  Otherwise, if an
      application-specific maximum number of roles have been visited, then go to
-     step 5.6 (so that attackers cannot cause the client to waste excessive
+     step [[#fetch-target]] (so that attackers cannot cause the client to waste excessive
      bandwidth or time).  Otherwise, if this role contains metadata about the
      desired target, then go to step [[#fetch-target]].
 
@@ -1564,7 +1564,7 @@ the latest trusted version) of the root metadata is available from the
 repository. This ensures that an outdated client can always correctly
 re-trace the chain of trust across multiple root key updates, even if the
 latest set of root keys on the client dates back multiple root metadata
-versions. See step 5.2 of the client application workflow for more details.
+versions. See step [[#update-root]]  of the client application workflow for more details.
 
 Note that an attacker, who controls the repository, can launch freeze
 attacks by withholding new root metadata. The attacker does not need to
@@ -1643,7 +1643,7 @@ so that outdated clients can update to the latest available root.
 
 ## Reading consistent snapshots ## {#reading-consistent-snapshots}
 
-See section 5 (The client application) for more details.
+See [[#detailed-client-workflow]] for more details.
 
 # Future directions and open questions # {#future-directions-and-open-questions}
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -504,8 +504,8 @@ deterministically by default so that signatures can be accurately verified.
 The chosen data format should be documented in the POUF of the implementation.
 The examples in this document use a subset of the JSON object format, with
 floating-point numbers omitted.  When calculating the digest of an
-object, we use the "canonical JSON" subdialect as described at
-    http://wiki.laptop.org/go/Canonical_JSON
+object, we use the "canonical JSON" subdialect as described at [Canonical JSON](
+http://wiki.laptop.org/go/Canonical_JSON).
 
 ## File formats: general principles ## {#file-formats-general-principles}
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -527,7 +527,8 @@ All signed metadata objects have the format:
 
       : <dfn for="role">KEYID</dfn>
       ::
-        The identifier of the key signing the <a for="role">ROLE</a> dictionary.
+        The identifier of the key signing the <a for="role">ROLE</a> object,
+        which is a hexdigest of the SHA-256 hash of the canonical form of the key.
 
       : <dfn>SIGNATURE</dfn>
       ::
@@ -634,9 +635,6 @@ The <dfn for="keytype">"ecdsa-sha2-nistp256"</dfn> format is:
   : <dfn for="keyval-ecdsa">PUBLIC</dfn>
   ::
     PEM format and a string.
-
-The <a for="role">KEYID</a> of a key is the hexdigest of the SHA-256 hash of
-the canonical form of the key.
 
 Metadata <dfn>date-time</dfn> follows the ISO 8601 standard.  The expected
 format of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1289,13 +1289,12 @@ it in the next step.
 
 ## Update the root role ## {#update-root}
 
-1. Since it may now be signed using
-  entirely different keys, the client MUST somehow be able to establish a
-  trusted line of continuity to the latest set of keys (see Section 6.1). To do
-  so, the client MUST download intermediate root metadata files, until the
-  latest available one is reached. Therefore, it MUST temporarily turn on
-  consistent snapshots in order to download _versioned_ root metadata files as
-  described next.
+1. Since it may now be signed using entirely different keys, the client MUST
+  somehow be able to establish a trusted line of continuity to the latest set
+  of keys (see [[#key-management-and-migration]]).  To do so, the client MUST
+  download intermediate root metadata files, until the latest available one is
+  reached.  Therefore, it MUST temporarily turn on consistent snapshots in
+  order to download *versioned* root metadata files as described next.
 
 1. Let N denote the version number of the trusted root metadata
   file.
@@ -1306,7 +1305,7 @@ it in the next step.
   kilobytes. The filename used to download the root metadata file is of the
   fixed form VERSION_NUMBER.FILENAME.EXT (e.g., 42.root.json). If this file is
   not available, or we have downloaded more than Y number of root metadata
-  files (because the exact number is as yet unknown), then go to step 5.2.9.
+  files (because the exact number is as yet unknown), then go to step 5.3.10.
   The value for Y is set by the authors of the application using TUF. For
   example, Y may be 2^10.
 
@@ -1316,7 +1315,7 @@ it in the next step.
   specified in the new root metadata file being validated (version N+1).  If
   version N+1 is not signed as required, discard it, abort the update cycle,
   and report the signature failure.  On the next update cycle, begin at step
-  5.1 and version N of the root metadata file.
+  [[#update-root]] and version N of the root metadata file.
 
 1. **Check for a rollback attack.** The version number of the trusted
   root metadata file (version N) MUST be less than or equal to the version
@@ -1324,11 +1323,11 @@ it in the next step.
   checking that the version number signed in the new root metadata file is
   indeed N+1.  If the version of the new root metadata file is less than the
   trusted metadata file, discard it, abort the update cycle, and report the
-  rollback attack.  On the next update cycle, begin at step 5.1 and version N
-  of the root metadata file.
+  rollback attack.  On the next update cycle, begin at step [[#update-root]]
+  and version N of the root metadata file.
 
 1. Note that the expiration of the new (intermediate) root metadata
-  file does not matter yet, because we will check for it in step 5.2.9.
+  file does not matter yet, because we will check for it in step 5.3.10.
 
 1. **Set the trusted root metadata file** to the new root metadata
   file.
@@ -1336,7 +1335,7 @@ it in the next step.
 1. **Persist root metadata.** The client MUST write the file to
   non-volatile storage as FILENAME.EXT (e.g. root.json).
 
-1. Repeat steps 5.2.1 to 5.2.8
+1. Repeat steps 5.3.1 to 5.3.8
 
 1. **Check for a freeze attack.** The expiration timestamp in the
   trusted root metadata file MUST be higher than the fixed update start time.
@@ -1355,7 +1354,7 @@ it in the next step.
   for more details.
 
 1. **Set whether consistent snapshots are used as per the trusted**
-    root metadata file (see Section 4.3).
+    root metadata file (see [[#file-formats-root]]).
 
 ## Update the timestamp role ## {#update-timestamp}
 
@@ -1399,11 +1398,12 @@ it in the next step.
   specified in the timestamp metadata file, or some Y number of bytes. The value
   for Y is set by the authors of the application using TUF. For example, Y may be
   tens of kilobytes. If consistent snapshots are not used (see
-  Section 7), then the filename used to download the snapshot metadata file is of
-  the fixed form FILENAME.EXT (e.g., snapshot.json).  Otherwise, the filename is
-  of the form VERSION_NUMBER.FILENAME.EXT (e.g., 42.snapshot.json), where
-  VERSION_NUMBER is the version number of the snapshot metadata file listed in
-  the timestamp metadata file.
+  Section [[#consistent-snapshots]]), then the filename used to download the
+  snapshot metadata file is of the fixed form FILENAME.EXT (e.g.,
+  snapshot.json).  Otherwise, the filename is of the form
+  VERSION_NUMBER.FILENAME.EXT (e.g., 42.snapshot.json), where VERSION_NUMBER is
+  the version number of the snapshot metadata file listed in the timestamp
+  metadata file.
 
 1. **Check against timestamp role's snapshot hash**. The hashes
   of the new snapshot metadata file MUST match the hashes, if any, listed in
@@ -1448,11 +1448,11 @@ it in the next step.
   number of bytes specified in the snapshot metadata file, or some Z number of
   bytes. The value for Z is set by the authors of the application using TUF. For
   example, Z may be tens of kilobytes.  If consistent snapshots are not used (see
-  Section 7), then the filename used to download the targets metadata file is of
-  the fixed form FILENAME.EXT (e.g., targets.json).  Otherwise, the filename is
-  of the form VERSION_NUMBER.FILENAME.EXT (e.g., 42.targets.json), where
-  VERSION_NUMBER is the version number of the targets metadata file listed in the
-  snapshot metadata file.
+  [[#consistent-snapshots]]), then the filename used to download the targets
+  metadata file is of the fixed form FILENAME.EXT (e.g., targets.json).
+  Otherwise, the filename is of the form VERSION_NUMBER.FILENAME.EXT (e.g.,
+  42.targets.json), where VERSION_NUMBER is the version number of the targets
+  metadata file listed in the snapshot metadata file.
 
 1. **Check against snapshot role's targets hash**. The hashes
   of the new targets metadata file MUST match the hashes, if any, listed in the
@@ -1482,7 +1482,7 @@ it in the next step.
 
 1. **Perform a pre-order depth-first search for metadata about the
   desired target, beginning with the top-level targets role.** Note: If
-  any metadata requested in steps 5.5.6.1 - 5.5.6.2 cannot be downloaded nor
+  any metadata requested in steps 5.6.7.1 - 5.6.7.2 cannot be downloaded nor
   validated, end the search and report that the target cannot be found.
 
   1. If this role has been visited before, then skip this role
@@ -1490,7 +1490,7 @@ it in the next step.
      application-specific maximum number of roles have been visited, then go to
      step 5.6 (so that attackers cannot cause the client to waste excessive
      bandwidth or time).  Otherwise, if this role contains metadata about the
-     desired target, then go to step 5.6.
+     desired target, then go to step [[#fetch-target]].
 
   1. Otherwise, recursively search the list of delegations in
      order of appearance.
@@ -1501,11 +1501,11 @@ it in the next step.
        the lack of any such metadata).
 
     1. If the current delegation is a terminating delegation,
-       then jump to step 5.6.
+       then jump to step [[#fetch-target]].
 
     1. Otherwise, if the current delegation is a
        non-terminating delegation, continue processing the next delegation, if
-       any. Stop the search, and jump to step 5.6 as soon as a delegation
+       any. Stop the search, and jump to step [[#fetch-target]] as soon as a delegation
        returns a result.
 
 ## Fetch target ## {#fetch-target}
@@ -1521,14 +1521,14 @@ it in the next step.
    cases, the exact number is unknown. This may happen, for example, if an
    external program is used to compute the root hash of a tree of targets files,
    and this program does not provide the total size of all of these files.) If
-   consistent snapshots are not used (see Section 7), then the filename used to
-   download the target file is of the fixed form FILENAME.EXT (e.g.,
-   foobar.tar.gz).  Otherwise, the filename is of the form HASH.FILENAME.EXT
-   (e.g.,
+   consistent snapshots are not used (see [[#consistent-snapshots]]), then the
+   filename used to download the target file is of the fixed form FILENAME.EXT
+   (e.g., foobar.tar.gz).  Otherwise, the filename is of the form
+   HASH.FILENAME.EXT (e.g.,
    c14aeb4ac9f4a8fc0d83d12482b9197452f6adf3eb710e3b1e2b79e8d14cb681.foobar.tar.gz),
    where HASH is one of the hashes of the targets file listed in the targets
-   metadata file found earlier in step 5.5.  In either case, the client MUST write
-   the file to non-volatile storage as FILENAME.EXT.
+   metadata file found earlier in step [[#update-targets]].  In either
+   case, the client MUST write the file to non-volatile storage as FILENAME.EXT.
 
 # 6. Usage # {#usage}
 


### PR DESCRIPTION
This PR lays the groundwork for #121 and is based on the excellent initial work by @erickt.

You can see a rendered version of the bikesheded specification document here: https://joshuagl.github.io/specification/

The major changes in this PR are:
* Convert tuf-spec.md to Bikeshed Flavoured Markdown (bfm) in 2be515a
* Start adopting some of the bfm features in 0713382 and c714c04. __NOTE__ until this point the content of the spec is unchanged, all of the changes are stylistic
* Changes the wording of some of the object field definitions, to better match the new layout and style, in 211ffbf
* Misc. tweaks in remaining commmits

I've been pleasantly surprised by how readable the [raw document](https://raw.githubusercontent.com/joshuagl/specification/joshuagl/bikeshed-initial/tuf-spec.md) still is, and how nice the rendered version looks. The styling of code blocks, cross-linking of definitions, and hyper-linked contents are a major improvement to the readability of the rendered specification.

Because the raw version isn't significantly more complex to edit, but handling additional changes to the specification makes maintaining this in a branch awkward, I would like to propose that we consider merging this PR and continuing to work on next steps (see below) with additional PRs against the main branch.

cc @JustinCappos @trishankatdatadog @mnm678 @lukpueh 

Next steps:
* Agree whether to proceed with switching to Bikeshed flavoured Markdown & merge this PR
* Define a CI pipeline that will
  * automatically publish updated versions of the specification (master branch) to i.e theupdateframework.github.io/specification
  * preserve, in a versioned location, a published version for each tagged release of the specification to i.e. theupdateframework.github.io/specification/1.0.16/
  * automatically publish updated version of the draft specification (draft branch) to i.e. theupdateframework.github.io/specification/draft
* Convert the detailed client workflow to call out to subsections (see #121)