### PR TITLE
Add more text describing threshold computation

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -3,7 +3,7 @@ Title: The Update Framework Specification
 Shortname: TUF
 Status: LS
 Abstract: A framework for securing software update systems.
-Date: 2023-03-02
+Date: 2023-04-14
 Editor: Justin Cappos, NYU
 Editor: Trishank Karthik Kuppusamy, Datadog
 Editor: Joshua Lock, Verizon
@@ -16,7 +16,7 @@ Boilerplate: copyright no, conformance no
 Local Boilerplate: header yes
 Markup Shorthands: css no, markdown yes
 Metadata Include: This version off, Abstract off
-Text Macro: VERSION 1.0.32
+Text Macro: VERSION 1.0.33
 </pre>
 
 Note: We strive to make the specification easy to implement, so if you come

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1322,11 +1322,15 @@ it in the next step.
   example, Y may be 2^10.
 
 4. **Check for an arbitrary software attack.** Version N+1 of the root
-  metadata file MUST have been signed by: (1) a threshold of keys specified in
-  the trusted root metadata file (version N), and (2) a threshold of keys
-  specified in the new root metadata file being validated (version N+1).  If
-  version N+1 is not signed as required, discard it, abort the update cycle,
-  and report the signature failure.
+  metadata file MUST have been signed by: (1) a <a>THRESHOLD</a> of keys
+  specified in the trusted root metadata file (version N), and (2) a
+  <a>THRESHOLD</a> of keys specified in the new root metadata file being
+  validated (version N+1).  When computing the <a>THRESHOLD</a> each
+  <a>KEY</a> must ONLY contribute one <a>SIGNATURE</a> towards the
+  <a>THRESHOLD</a>, even if the <a>KEY</a> is listed more than once in a role's
+  signatures field.  If version N+1 is not signed as required, discard it, abort
+  the update cycle, and report the signature failure.  On the next update cycle,
+  begin at step [[#update-root]] and version N of the root metadata file.
 
 5. **Check for a rollback attack.** The version number of the new root
   metadata (version N+1) MUST be exactly the version in the trusted root
@@ -1372,10 +1376,12 @@ it in the next step.
   (e.g., timestamp.json).
 
 2. **Check for an arbitrary software attack.** The new timestamp
-  metadata file MUST have been signed by a threshold of keys specified in the
-  trusted root metadata file. If the new timestamp metadata file is not
-  properly signed, discard it, abort the update cycle, and report the signature
-  failure.
+  metadata file MUST have been signed by a <a>THRESHOLD</a> of keys specified in
+  the trusted root metadata file.  When computing the <a>THRESHOLD</a> each
+  <a>KEY</a> must ONLY contribute one <a>SIGNATURE</a> towards the
+  <a>THRESHOLD</a>, even if the <a>KEY</a> is listed more than once in a role's
+  signatures field.  If the new timestamp metadata file is not properly signed,
+  discard it, abort the update cycle, and report the signature failure.
 
 3. **Check for a rollback attack.**
 
@@ -1426,9 +1432,12 @@ it in the next step.
   new snapshot metadata, abort the update cycle, and report the failure.
 
 3. **Check for an arbitrary software attack**. The new snapshot
-  metadata file MUST have been signed by a threshold of keys specified in the
-  trusted root metadata file.  If the new snapshot metadata file is not signed
-  as required, discard it, abort the update cycle, and report the signature
+  metadata file MUST have been signed by a <a>THRESHOLD</a> of keys specified in
+  the trusted root metadata file.  When computing the <a>THRESHOLD</a> each
+  <a>KEY</a> must ONLY contribute one <a>SIGNATURE</a> towards the
+  <a>THRESHOLD</a>, even if the <a>KEY</a> is listed more than once in a role's
+  signatures field.  If the new snapshot metadata file is not signed as
+  required, discard it, abort the update cycle, and report the signature
   failure.
 
 4. **Check against timestamp role's snapshot version**. The version
@@ -1477,9 +1486,12 @@ it in the next step.
   target metadata, abort the update cycle, and report the failure.
 
 3. **Check for an arbitrary software attack**. The new targets
-  metadata file MUST have been signed by a threshold of keys specified in the
-  trusted root metadata file.  If the new targets metadata file is not signed
-  as required, discard it, abort the update cycle, and report the failure.
+  metadata file MUST have been signed by a <a>THRESHOLD</a> of keys specified in
+  the trusted root metadata file.  When computing the <a>THRESHOLD</a> each
+  <a>KEY</a> must ONLY contribute one <a>SIGNATURE</a> towards the
+  <a>THRESHOLD</a>, even if the <a>KEY</a> is listed more than once in a role's
+  signatures field.  If the new targets metadata file is not signed as required,
+  discard it, abort the update cycle, and report the failure.
 
 4. **Check against snapshot role's targets version**. The version
   number of the new targets metadata file MUST match the version number listed

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -547,6 +547,11 @@ All signed metadata objects have the format:
       ::
         A hex-encoded signature of the canonical form of the metadata for <a for="role">ROLE</a>.
 
+Note: The "signatures" list SHOULD only contain one <a>SIGNATURE</a> per
+<a for="role">KEYID</a>. This helps prevent multiple signatures by the same key
+being counted erroneously towards the minimum <a>THRESHOLD</a> indicating valid
+metadata.
+
 ### Key objects ### {#file-formats-keys}
 
 All <dfn>KEY</dfn> objects have the format:

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -550,7 +550,8 @@ All signed metadata objects have the format:
 Note: The "signatures" list SHOULD only contain one <a>SIGNATURE</a> per
 <a for="role">KEYID</a>. This helps prevent multiple signatures by the same key
 being counted erroneously towards the minimum <a>THRESHOLD</a> indicating valid
-metadata.
+metadata. <a>THRESHOLD</a> counting is further described in the relevant steps
+of [[#detailed-client-workflow]].
 
 ### Key objects ### {#file-formats-keys}
 
@@ -1331,11 +1332,14 @@ it in the next step.
   specified in the trusted root metadata file (version N), and (2) a
   <a>THRESHOLD</a> of keys specified in the new root metadata file being
   validated (version N+1).  When computing the <a>THRESHOLD</a> each
-  <a>KEY</a> must ONLY contribute one <a>SIGNATURE</a> towards the
-  <a>THRESHOLD</a>, even if the <a>KEY</a> is listed more than once in a role's
-  signatures field.  If version N+1 is not signed as required, discard it, abort
-  the update cycle, and report the signature failure.  On the next update cycle,
-  begin at step [[#update-root]] and version N of the root metadata file.
+  <a>KEY</a> MUST only contribute one <a>SIGNATURE</a>. That is, each
+  <a>SIGNATURE</a> which is counted towards the <a>THRESHOLD</a> MUST have
+  a unique <a>KEYID</a>. Even if a <a>KEYID</a> is listed more than once in the
+  "signatures" list a client MUST NOT count more than one verified
+  <a>SIGNATURE</a> from that <a>KEYID</a> towards the <a>THRESHOLD</a>.
+  If version N+1 is not signed as required, discard it, abort the update cycle,
+  and report the signature failure.  On the next update cycle, begin at step
+  [[#update-root]] and version N of the root metadata file.
 
 5. **Check for a rollback attack.** The version number of the new root
   metadata (version N+1) MUST be exactly the version in the trusted root
@@ -1381,12 +1385,15 @@ it in the next step.
   (e.g., timestamp.json).
 
 2. **Check for an arbitrary software attack.** The new timestamp
-  metadata file MUST have been signed by a <a>THRESHOLD</a> of keys specified in
-  the trusted root metadata file.  When computing the <a>THRESHOLD</a> each
-  <a>KEY</a> must ONLY contribute one <a>SIGNATURE</a> towards the
-  <a>THRESHOLD</a>, even if the <a>KEY</a> is listed more than once in a role's
-  signatures field.  If the new timestamp metadata file is not properly signed,
-  discard it, abort the update cycle, and report the signature failure.
+  metadata file MUST have been signed by a <a>THRESHOLD</a> of keys specified
+  in the trusted root metadata file.  When computing the <a>THRESHOLD</a> each
+  <a>KEY</a> MUST only contribute one <a>SIGNATURE</a>. That is, each
+  <a>SIGNATURE</a> which is counted towards the <a>THRESHOLD</a> MUST have
+  a unique <a>KEYID</a>. Even if a <a>KEYID</a> is listed more than once in the
+  "signatures" list a client MUST NOT count more than one verified
+  <a>SIGNATURE</a> from that <a>KEYID</a> towards the <a>THRESHOLD</a>.  If the
+  new timestamp metadata file is not properly signed, discard it, abort the
+  update cycle, and report the signature failure.
 
 3. **Check for a rollback attack.**
 
@@ -1439,11 +1446,13 @@ it in the next step.
 3. **Check for an arbitrary software attack**. The new snapshot
   metadata file MUST have been signed by a <a>THRESHOLD</a> of keys specified in
   the trusted root metadata file.  When computing the <a>THRESHOLD</a> each
-  <a>KEY</a> must ONLY contribute one <a>SIGNATURE</a> towards the
-  <a>THRESHOLD</a>, even if the <a>KEY</a> is listed more than once in a role's
-  signatures field.  If the new snapshot metadata file is not signed as
-  required, discard it, abort the update cycle, and report the signature
-  failure.
+  <a>KEY</a> MUST only contribute one <a>SIGNATURE</a>. That is, each
+  <a>SIGNATURE</a> which is counted towards the <a>THRESHOLD</a> MUST have
+  a unique <a>KEYID</a>. Even if a <a>KEYID</a> is listed more than once in the
+  "signatures" list a client MUST NOT count more than one verified
+  <a>SIGNATURE</a> from that <a>KEYID</a> towards the <a>THRESHOLD</a>.  If the
+  new snapshot metadata file is not signed as required, discard it, abort the
+  update cycle, and report the signature failure.
 
 4. **Check against timestamp role's snapshot version**. The version
   number of the new snapshot metadata file MUST match the version number listed
@@ -1491,12 +1500,15 @@ it in the next step.
   target metadata, abort the update cycle, and report the failure.
 
 3. **Check for an arbitrary software attack**. The new targets
-  metadata file MUST have been signed by a <a>THRESHOLD</a> of keys specified in
-  the trusted root metadata file.  When computing the <a>THRESHOLD</a> each
-  <a>KEY</a> must ONLY contribute one <a>SIGNATURE</a> towards the
-  <a>THRESHOLD</a>, even if the <a>KEY</a> is listed more than once in a role's
-  signatures field.  If the new targets metadata file is not signed as required,
-  discard it, abort the update cycle, and report the failure.
+  metadata file MUST have been signed by a <a>THRESHOLD</a> of keys specified
+  in the trusted root metadata file.  When computing the <a>THRESHOLD</a> each
+  <a>KEY</a> MUST only contribute one <a>SIGNATURE</a>. That is, each
+  <a>SIGNATURE</a> which is counted towards the <a>THRESHOLD</a> MUST have a
+  unique <a>KEYID</a>. Even if a <a>KEYID</a> is listed more than once in the
+  "signatures" list a client MUST NOT count more than one verified
+  <a>SIGNATURE</a> from that <a>KEYID</a> towards the <a>THRESHOLD</a>.  If the
+  new targets metadata file is not signed as required, discard it, abort the
+  update cycle, and report the failure.
 
 4. **Check against snapshot role's targets version**. The version
   number of the new targets metadata file MUST match the version number listed


### PR DESCRIPTION
Add some additional text to each "Check for an arbitrary software attack" section describing threshold computation, in an attempt to help TUF implementers avoid falling into the trap of a naive implementation of threshold counting resulting in incorrect, security affecting, behaviour. 

Further enhance this guidance by recommending, in "File formats", that the signatures list only contain one signature per keyid.

This kind of detail will be easier to add in a much clearer way once we rewrite the workflow to call out to subsections (https://github.com/theupdateframework/specification/issues/121), however I wanted to add this information as soon as possible because we continue to see implementers falling into the same trap:
* [Incorrect threshold signature computation](https://github.com/theupdateframework/tuf/security/advisories/GHSA-pwqf-9h7j-7mv8) in the reference implementation.
* [Incorrect threshold signature computation for new root metadata](https://github.com/theupdateframework/tuf/commit/83ac7be525b733f79a7e9bc573ec580ec835f179) in the reference implementation.
* [Improper uniqueness verification of signature threshold](https://github.com/awslabs/tough/security/advisories/GHSA-5q2r-92f9-4m49) in Tough.
* [Deduplicate signatures with the same key_id](https://github.com/heartsucker/rust-tuf/commit/1f80ec14d3171246568048c69af65ecb028e909e) in rust-tuf.
* [Fix duplicate signature validation](https://github.com/advancedtelematic/aktualizr/commit/2880edc13dccadb634975810575ab6f144e3b95e) in aktualizer (an Uptane implementation).
* [Only consider the count of valid keys to verify thresholds](https://github.com/theupdateframework/go-tuf/commit/3ebc49bbf99db8d705a4759caa2b8c9d582d6031) in go-tuf.
* [Incorrect threshold signature computation](https://github.com/php-tuf/php-tuf/issues/154) in php-tuf.