### PR TITLE
Clarify optional attributes

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -3,7 +3,7 @@ Title: The Update Framework Specification
 Shortname: TUF
 Status: LS
 Abstract: A framework for securing software update systems.
-Date: 2021-05-27
+Date: 2021-05-31
 Editor: Justin Cappos, NYU
 Editor: Trishank Karthik Kuppusamy, Datadog
 Editor: Joshua Lock, VMware
@@ -16,7 +16,7 @@ Boilerplate: copyright no, conformance no
 Local Boilerplate: header yes
 Markup Shorthands: css no, markdown yes
 Metadata Include: This version off, Abstract off
-Text Macro: VERSION 1.0.19
+Text Macro: VERSION 1.0.20
 </pre>
 
 Note: We strive to make the specification easy to implement, so if you come
@@ -976,7 +976,8 @@ as is described for the <a>root.json</a> file.
     <a>TARGETPATH</a>.  The application may use this information to guide
     download decisions.
 
-<dfn>DELEGATIONS</dfn> is an object whose format is the following:
+<dfn>DELEGATIONS</dfn> is an OPTIONAL object and if defined it has the following
+format:
 
 <pre highlight="json">
 {

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1021,9 +1021,8 @@ format:
     package that are not made by the delegated party or its descendants to be
     ignored.
 
-In order to discuss target paths, a role MUST specify only one of the
-<a>"path_hash_prefixes"</a> or <a for="delegation-role">"paths"</a> attributes, each of which we
-discuss next.
+The <a>"path_hash_prefixes"</a> and <a for="delegation-role">"paths"</a>
+attributes are OPTIONAL, if used, exactly one of them should be set.
 
   : <dfn>"path_hash_prefixes"</dfn>
   ::

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -688,9 +688,11 @@ The "signed" portion of <a>root.json</a> is as follows:
 
   : <dfn>CONSISTENT_SNAPSHOT</dfn>
   ::
-    A boolean indicating whether the repository supports
-    consistent snapshots.  Section [[#consistent-snapshots]] goes into more
-    detail on the consequences of enabling this setting on a repository.
+    An OPTIONAL boolean indicating whether the repository supports
+    consistent snapshots. This field is OPTIONAL for backward compatibility with
+    old metadata. New implementations SHOULD include it. Section
+    [[#consistent-snapshots]] goes into more detail on the consequences of
+    enabling this setting on a repository.
 
   : <dfn for="role">VERSION</dfn>
   ::

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -691,7 +691,7 @@ The "signed" portion of <a>root.json</a> is as follows:
   : <dfn>CONSISTENT_SNAPSHOT</dfn>
   ::
     An OPTIONAL boolean indicating whether the repository supports
-    consistent snapshots. This field is OPTIONAL for backward compatibility with
+    consistent snapshots. This field is OPTIONAL for backwards compatibility with
     old metadata. New implementations SHOULD include it. Section
     [[#consistent-snapshots]] goes into more detail on the consequences of
     enabling this setting on a repository.


### PR DESCRIPTION
This pr merges changes from #157, #158, and #162 into one for an easier review process and
merging (considering we have to bump the version on each merge)
and closes https://github.com/theupdateframework/specification/issues/156.

This pr makes three changes
- make `delegations` optional
- make `consistent_snapshot` optional
- clarify which of `paths` and `path_hash_prefixes` can be used and when

Nowhere in the spec, we clarify that `delegations` is an optional field
in the targets, metadata file which is implied by the file format scheme showed for targets [here](https://theupdateframework.github.io/specification/latest/index.html#file-formats-targets).

From chapter [6.2.1](https://theupdateframework.github.io/specification/latest/index.html#writing-consistent-snapshots) in the tuf specification (version 1.019)
```
Finally, the root metadata should write the Boolean
"consistent_snapshot" attribute at the root level of its keys of
attributes.
If consistent snapshots are not written by the repository,
then the attribute may either be left unspecified or be set
to the False value. Otherwise, it must be set to the True value.
```

The above implies that there could be repositories with root metadata
without `CONSISTENT_SNAPSHOT`.
Clarify that, but phrase it so it's clear this should be included
in new implementations.

Finally, clarify `paths` and `path_hash_prefixes` in delegations, because
currently, it's not properly defined which of these options can be used
to create a valid target file:
- **BOTH** `paths` and `path_hash_prefixes`
- **ONLY ONE** of `paths` and `path_hash_prefixes`
- **NONE** of `paths` and `path_hash_prefixes`

With this change, I aim to define clearly that a valid target file will
contain **ONLY ONE** or **NONE** of them.
