### PR TITLE
Add guidance about unknown fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "editor.wordWrap": "wordWrapColumn",
-    "[markdown]": {
-    
-        "editor.wordWrap": "on",
-        "editor.quickSuggestions": false,
-        "editor.wordWrapColumn": 80
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "editor.wordWrap": "wordWrapColumn",
+    "[markdown]": {
+    
+        "editor.wordWrap": "on",
+        "editor.quickSuggestions": false,
+        "editor.wordWrapColumn": 80
+    }
+}

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -3,7 +3,7 @@ Title: The Update Framework Specification
 Shortname: TUF
 Status: LS
 Abstract: A framework for securing software update systems.
-Date: 2021-05-27
+Date: 2021-06-11
 Editor: Justin Cappos, NYU
 Editor: Trishank Karthik Kuppusamy, Datadog
 Editor: Joshua Lock, VMware
@@ -16,7 +16,7 @@ Boilerplate: copyright no, conformance no
 Local Boilerplate: header yes
 Markup Shorthands: css no, markdown yes
 Metadata Include: This version off, Abstract off
-Text Macro: VERSION 1.0.19
+Text Macro: VERSION 1.0.20
 </pre>
 
 Note: We strive to make the specification easy to implement, so if you come
@@ -490,9 +490,11 @@ A delegated role file is located at:
 # Document formats # {#document-formats}
 
 All of the formats described below include the ability to add more
-attribute-value fields for backwards-compatible format changes.  If
-a backwards incompatible format change is needed, a new filename can
-be used.
+attribute-value fields to dictionary objects for backwards-compatible format
+changes.  Implementers who encounter undefined key-value pairs in the format
+must include the data when calculating hashes or verifying signatures and must
+preserve the data when re-serializing. If a backwards incompatible format change
+is needed, a new filename can be used.
 
 ## Metaformat ## {#metaformat}
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -490,7 +490,7 @@ A delegated role file is located at:
 # Document formats # {#document-formats}
 
 All of the formats described below include the ability to add more
-attribute-value fields to dictionary objects for backwards-compatible format
+key-value fields to dictionary objects for backwards-compatible format
 changes.  Implementers who encounter undefined key-value pairs in the format
 must include the data when calculating hashes or verifying signatures and must
 preserve the data when re-serializing. If a backwards incompatible format change

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -490,8 +490,8 @@ A delegated role file is located at:
 # Document formats # {#document-formats}
 
 All of the formats described below include the ability to add more
-key-value fields to dictionary objects for backwards-compatible format
-changes.  Implementers who encounter undefined key-value pairs in the format
+attribute-value fields to objects for backwards-compatible format changes.
+Implementers who encounter undefined attribute-value pairs in the format
 must include the data when calculating hashes or verifying signatures and must
 preserve the data when re-serializing. If a backwards incompatible format change
 is needed, a new filename can be used.

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -3,7 +3,7 @@ Title: The Update Framework Specification
 Shortname: TUF
 Status: LS
 Abstract: A framework for securing software update systems.
-Date: 2021-06-11
+Date: 2021-06-14
 Editor: Justin Cappos, NYU
 Editor: Trishank Karthik Kuppusamy, Datadog
 Editor: Joshua Lock, VMware


### PR DESCRIPTION
https://github.com/theupdateframework/specification/issues/163

Addressing this, specify that implementers should preserve unknown key-value pairs and include them in calculating hashes or verifying signatures.

I would like to add examples here, but it feels like an awkward place if the format hasn't been defined at this point in the spec.

Signed-off-by: Asra Ali <asraa@google.com>