### PR TITLE
feat: add reusable workflow for autofilling an issue when there's a new TUF version

### DIFF
--- a/.github/workflows/check-latest-spec-version.yml
+++ b/.github/workflows/check-latest-spec-version.yml
@@ -19,12 +19,12 @@ jobs:
               owner: "theupdateframework",
               repo: "specification"
             });
-            const spec_version = release.data.tag_name
+            const latest_version = release.data.tag_name
             const supported_version = "${{ inputs.tuf-version }}"
             const repo = context.repo.owner + "/" + context.repo.repo
-            if (spec_version != supported_version) {
+            if (latest_version != supported_version) {
               console.log(
-                "The latest TUF specification version (" + spec_version + ") does not match with the version that " + repo + " supports (" +
+                "The latest TUF specification version (" + latest_version + ") does not match with the version that " + repo + " supports (" +
                   supported_version + ")"
               )
               const issues = await github.rest.search.issuesAndPullRequests({
@@ -36,12 +36,14 @@ jobs:
                 await github.rest.issues.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  title: "TUF specification has a new version - " + spec_version,
-                  body: "Hey, it seems there's a newer version of the TUF specification - [" + spec_version +
-                        "](https://github.com/theupdateframework/specification/blob/" + spec_version + "/tuf-spec.md)" +
+                  title: "TUF specification has a new version - " + latest_version,
+                  body: "Hey, it seems there's a newer version of the TUF specification - [" + latest_version +
+                        "](https://github.com/theupdateframework/specification/blob/" + latest_version + "/tuf-spec.md)" +
                         "\n\n" + 
-                        "For comparison, the version which [" + repo + "](https://github.com/" + repo + ") state it supports is - [" + supported_version +
+                        "The version which [" + repo + "](https://github.com/" + repo + ") state it supports is - [" + supported_version +
                         "](https://github.com/theupdateframework/specification/blob/" + supported_version + "/tuf-spec.md)" + 
+                        "\n\n" +
+                        "The following is a comparison of what changed between the two versions - [Compare " + supported_version + " to " + latest_version +"](https://github.com/theupdateframework/specification/compare/" + supported_version + "..." + latest_version + ")" +
                         "\n\n" +
                         "Please review the newer version and address the changes."
                 })
@@ -49,7 +51,7 @@ jobs:
               }
             } else {
               console.log(
-                "The latest TUF specification version (" + spec_version + ") matches with the version that " + repo + " supports (" +
+                "The latest TUF specification version (" + latest_version + ") matches with the version that " + repo + " supports (" +
                   supported_version + ")"
               )
             }

--- a/.github/workflows/check-latest-spec-version.yml
+++ b/.github/workflows/check-latest-spec-version.yml
@@ -2,7 +2,7 @@
 # This is a reusable workflow that can be used by projects to keep track of
 # new TUF specification releases. It automatically opens an issue to notify
 # the project in case the released version is different from what the project
-# state it supports.
+# states it supports.
 #
 # Usage:
 # The following is an example of how to use the workflow.
@@ -64,9 +64,9 @@ jobs:
                   title: "TUF specification has a new version - " + latest_version,
                   body: "Hey, it seems there's a newer version of the TUF specification - [" + latest_version +
                         "](https://github.com/theupdateframework/specification/blob/" + latest_version + "/tuf-spec.md)" +
-                        "\n\n" + 
-                        "The version which [" + repo + "](https://github.com/" + repo + ") state it supports is - [" + supported_version +
-                        "](https://github.com/theupdateframework/specification/blob/" + supported_version + "/tuf-spec.md)" + 
+                        "\n\n" +
+                        "The version which [" + repo + "](https://github.com/" + repo + ") states it supports is - [" + supported_version +
+                        "](https://github.com/theupdateframework/specification/blob/" + supported_version + "/tuf-spec.md)" +
                         "\n\n" +
                         "The following is a comparison of what changed between the two versions - [Compare " + supported_version + " to " + latest_version +"](https://github.com/theupdateframework/specification/compare/" + supported_version + "..." + latest_version + ")" +
                         "\n\n" +

--- a/.github/workflows/check-latest-spec-version.yml
+++ b/.github/workflows/check-latest-spec-version.yml
@@ -1,0 +1,55 @@
+on:
+  workflow_call:
+    inputs:
+      tuf-version:
+        required: true
+        type: string
+name: Get the latest TUF specification release and open an issue (if needed)
+jobs:
+  check-spec-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
+        with:
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: "theupdateframework",
+              repo: "specification"
+            });
+            const spec_version = release.data.tag_name
+            const supported_version = "${{ inputs.tuf-version }}"
+            const repo = context.repo.owner + "/" + context.repo.repo
+            if (spec_version != supported_version) {
+              console.log(
+                "The latest TUF specification version (" + spec_version + ") does not match with the version that " + repo + " supports (" +
+                  supported_version + ")"
+              )
+              const issues = await github.rest.search.issuesAndPullRequests({
+                q: "TUF+specification+has+a+new+version+in:title+state:open+type:issue+repo:" + repo,
+              })
+              if (issues.data.total_count > 0) {
+                console.log("There's already an open issue for that, therefore not creating.")
+              } else {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: "TUF specification has a new version - " + spec_version,
+                  body: "Hey, it seems there's a newer version of the TUF specification - [" + spec_version +
+                        "](https://github.com/theupdateframework/specification/blob/" + spec_version + "/tuf-spec.md)" +
+                        "\n\n" + 
+                        "For comparison, the version which [" + repo + "](https://github.com/" + repo + ") state it supports is - [" + supported_version +
+                        "](https://github.com/theupdateframework/specification/blob/" + supported_version + "/tuf-spec.md)" + 
+                        "\n\n" +
+                        "Please review the newer version and address the changes."
+                })
+                console.log("New issue created.")
+              }
+            } else {
+              console.log(
+                "The latest TUF specification version (" + spec_version + ") matches with the version that " + repo + " supports (" +
+                  supported_version + ")"
+              )
+            }

--- a/.github/workflows/check-latest-spec-version.yml
+++ b/.github/workflows/check-latest-spec-version.yml
@@ -1,3 +1,28 @@
+# Description:
+# This is a reusable workflow that can be used by projects to keep track of
+# new TUF specification releases. It automatically opens an issue to notify
+# the project in case the released version is different from what the project
+# state it supports.
+#
+# Usage:
+# The following is an example of how to use the workflow.
+#
+# Create a yml file inside the project's ".github/workflows/" directory with the following content:
+# on:
+#   schedule:
+#     - cron: "0 13 * * *"
+#   workflow_dispatch:
+# name: Specification version check
+# jobs:
+#   # Get the latest TUF specification release and open an issue (if needed)
+#   specification-bump-check:
+#     permissions:
+#       contents: read
+#       issues: write
+#     uses: theupdateframework/specification/.github/workflows/check-latest-spec-version.yml@master
+#     with:
+#       tuf-version: "v1.0.29" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.
+#
 on:
   workflow_call:
     inputs:

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,16 @@ The TUF specification uses `Semantic Versioning 2.0.0 <https://semver.org/>`_
   number.
 - Merges with 'master' must be followed by a rebase of 'draft' onto 'master'.
 
+Keep track of new TUF releases
+------------------------------
 
+There's a reusable workflow that can be used by projects to keep track of
+new TUF specification releases. It automatically opens an issue to notify
+the project in case the released version is different from what the project
+state it supports.
+
+The workflow, along with an example of how to use it, can be found at - `.github/workflows/check-latest-spec-version.yml
+<https://github.com/theupdateframework/specification/blob/master/.github/workflows/check-latest-spec-version.yml>`_.
 
 Acknowledgements
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ the project in case the released version is different from what the project
 state it supports.
 
 The workflow, along with an example of how to use it, can be found at - `.github/workflows/check-latest-spec-version.yml
-<https://github.com/theupdateframework/specification/blob/master/.github/workflows/check-latest-spec-version.yml>`_.
+</.github/workflows/check-latest-spec-version.yml>`_.
 
 Acknowledgements
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Keep track of new TUF releases
 There's a reusable workflow that can be used by projects to keep track of
 new TUF specification releases. It automatically opens an issue to notify
 the project in case the released version is different from what the project
-state it supports.
+states it supports.
 
 The workflow, along with an example of how to use it, can be found at - `.github/workflows/check-latest-spec-version.yml
 </.github/workflows/check-latest-spec-version.yml>`_.


### PR DESCRIPTION
The following adds a workflow that can be used by projects that want to keep track and be notified when there's a new version of the TUF specification. 

In case there's a newer version, it will file an issue against the project with several links, like the currently supported version, and a comparison showing what's changed. Here's an example of the issue it will create - 

**Title:** 
> TUF specification has a new version - v1.0.30

**Body:** 
> Hey, it seems there's a newer version of the TUF specification - [v1.0.30](https://github.com/theupdateframework/specification/blob/v1.0.30/tuf-spec.md)
> 
> The version which [rdimitrov/python-tuf](https://github.com/rdimitrov/python-tuf) state it supports is - [v1.0.29](https://github.com/theupdateframework/specification/blob/v1.0.29/tuf-spec.md)
> 
> The following is a comparison of what changed between the two versions - [Compare v1.0.29 to v1.0.30](https://github.com/theupdateframework/specification/compare/v1.0.29...v1.0.30)
> 
> Please review the newer version and address the changes.


**Note:** 
A few other PRs will be created and referenced here for https://github.com/theupdateframework/python-tuf and https://github.com/theupdateframework/go-tuf which can serve as examples of how to use this workflow.

Related to - https://github.com/theupdateframework/go-tuf/issues/283