### PR TITLE
Use new actions/setup-python builtin caching

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -13,18 +13,7 @@ jobs:
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
       with:
         python-version: 3.x
-
-    - name: Find pip cache dir
-      id: pip-cache
-      run: echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: pip cache
-      uses: actions/cache@a7c34adf76222e77931dedbf4a45b2e4648ced19
-      with:
-        # Use the os dependent pip cache directory found above
-        path: ${{ steps.pip-cache.outputs.dir }}
-        # A match with 'restore-keys' is used as fallback
-        key: ${{ runner.os }}-pip-
+        cache: pip
 
     - name: Clone
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Build specification
       run: |
-        python -m pip install bikeshed
+        python -m pip install -r requirements.txt
         mkdir build && cd build
         make -f ../Makefile draft
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,18 +17,7 @@ jobs:
         uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
         with:
           python-version: 3.x
-
-      - name: Find pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@a7c34adf76222e77931dedbf4a45b2e4648ced19
-        with:
-          # Use the os dependent pip cache directory found above
-          path: ${{ steps.pip-cache.outputs.dir }}
-          # A match with 'key' counts as cache hit
-          key: ${{ runner.os }}-pip-
+          cache: pip
 
       - name: Ensure changes build
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Ensure changes build
         run: |
-          python -m pip install bikeshed
+          python -m pip install -r requirements.txt
           mkdir build && cd build
           make -f ../Makefile spec
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Build specification
       if: steps.getver.outputs.spec_version != steps.prevver.outputs.prev_version
       run: |
-        python -m pip install bikeshed
+        python -m pip install -r requirements.txt
         mkdir build && cd build
         make -f ../Makefile release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,18 +13,7 @@ jobs:
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
       with:
         python-version: 3.x
-
-    - name: Find pip cache dir
-      id: pip-cache
-      run: echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: pip cache
-      uses: actions/cache@a7c34adf76222e77931dedbf4a45b2e4648ced19
-      with:
-        # Use the os dependent pip cache directory found above
-        path: ${{ steps.pip-cache.outputs.dir }}
-        # A match with 'key' counts as cache hit
-        key: ${{ runner.os }}-pip-
+        cache: 'pip'
 
     - name: Clone main
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+bikeshed


### PR DESCRIPTION
Replaces more laborious use of actions/cache in GitHub workflows.

Fixes #193
Closes #244

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>