### PR TITLE
Add TUF and in-toto schema files

### DIFF
--- a/schemas/in-toto-metadata-signer-x.schema.json
+++ b/schemas/in-toto-metadata-signer-x.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "signatures": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keyid": {
+              "type": "string",
+              "minLength": 64,
+              "maxLength": 64,
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "sig": {
+              "type": "string",
+              "minLength": 1024,
+              "maxLength": 1024,
+              "pattern": "^[a-f0-9]{1024}$"
+            }
+          },
+          "required": [
+            "keyid",
+            "sig"
+          ]
+        }
+      ]
+    },
+    "signed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "_type": {
+          "enum": ["targets"]
+        },
+        "delegations": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keys": {
+              "type": "object"
+            },
+            "roles": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "required": [
+            "keys",
+            "roles"
+          ]
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "spec_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "targets": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^(simple/[a-z-0-9]+/[a-z0-9-]+-py2\\.py3-none-any\\.whl)|(in-toto-metadata/[a-f0-9]{64}/((wheels-signer)|(tag)|(wheels-builder))\\.[a-f0-9]{8}\\.link)$": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "custom": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "in-toto": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "pattern": "in-toto-metadata/([a-f0-9]{64}/(wheels-signer|wheels-builder|tag)\\.[a-f0-9]{8}\\.link)|root.layout"
+                        }
+                      ]
+                    },
+                    "root-layout-type": {
+                      "enum": ["extras", "core"]
+                    }
+                  }
+                },
+                "hashes": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "sha256": {
+                      "type": "string",
+                      "minLength": 64,
+                      "maxLength": 64,
+                      "pattern": "^[a-f0-9]{64}$"
+                    },
+                    "sha512": {
+                      "type": "string",
+                      "minLength": 128,
+                      "maxLength": 128,
+                      "pattern": "^[a-f0-9]{128}$"
+                    }
+                  },
+                  "required": [
+                    "sha256",
+                    "sha512"
+                  ]
+                },
+                "length": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "custom",
+                "hashes",
+                "length"
+              ]
+            }
+          }
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "_type",
+        "delegations",
+        "expires",
+        "spec_version",
+        "targets",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "signatures",
+    "signed"
+  ]
+}

--- a/schemas/in-toto-metadata-signer.schema.json
+++ b/schemas/in-toto-metadata-signer.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "signatures": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "keyid": {
+              "type": "string",
+              "minLength": 64,
+              "maxLength": 64,
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "sig": {
+              "type": "string",
+              "minLength": 1024,
+              "maxLength": 1024,
+              "pattern": "^[a-f0-9]{1024}$"
+            }
+          },
+          "required": [
+            "keyid",
+            "sig"
+          ]
+        }
+      ]
+    },
+    "signed": {
+      "type": "object",
+      "properties": {
+        "_type": {
+          "enum": ["targets"]
+        },
+        "delegations": {
+          "type": "object",
+          "properties": {
+            "keys": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-f0-9]{64}$": {
+                  "type": "object",
+                  "properties": {
+                    "keyid_hash_algorithms": {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "sha256",
+                          "sha512"
+                        ]
+                      }
+                    },
+                    "keytype": {
+                      "enum": ["rsa"]
+                    },
+                    "keyval": {
+                      "type": "object",
+                      "properties": {
+                        "public": {
+                          "type": "string",
+                          "pattern": "^-----BEGIN PUBLIC KEY-----"
+                        }
+                      },
+                      "required": [
+                        "public"
+                      ]
+                    },
+                    "scheme": {
+                      "enum": ["rsassa-pss-sha256"]
+                    }
+                  },
+                  "required": [
+                    "keyid_hash_algorithms",
+                    "keytype",
+                    "keyval",
+                    "scheme"
+                  ]
+                }
+              }
+            },
+            "roles": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "keyids": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "minLength": 64,
+                          "maxLength": 64,
+                          "pattern": "^[a-f0-9]{64}$"
+                        }
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "pattern": "^in-toto-metadata-signer-[0-9a-f]$"
+                    },
+                    "paths": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "pattern": "^in-toto-metadata/[0-9a-f]\\*/\\*\\.link$"
+                        }
+                      ]
+                    },
+                    "terminating": {
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  },
+                  "required": [
+                    "keyids",
+                    "name",
+                    "paths",
+                    "terminating",
+                    "threshold"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "keys",
+            "roles"
+          ]
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "spec_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "targets": {
+          "type": "object"
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "_type",
+        "delegations",
+        "expires",
+        "spec_version",
+        "targets",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "signatures",
+    "signed"
+  ]
+}

--- a/schemas/root.schema.json
+++ b/schemas/root.schema.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": ["signatures", "signed"],
+  "additionalProperties": false,
+  "properties": {
+    "signatures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["keyid", "sig"],
+        "additionalProperties": false,
+        "properties": {
+          "keyid": {
+            "type": "string",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "sig": {
+            "type": "string",
+            "minLength": 1024,
+            "maxLength": 1024,
+            "pattern": "^[a-f0-9]{1024}$"
+          }
+        }
+      }
+    },
+    "signed": {
+      "type": "object",
+      "required": ["_type", "consistent_snapshot", "expires", "keys", "roles", "spec_version", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "_type": {
+          "enum": ["root"]
+        },
+        "consistent_snapshot": {
+          "type": "boolean"
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "keys": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[0-9a-f]{64}$": {
+              "type": "object",
+              "required": ["keyid_hash_algorithms", "keytype", "keyval", "scheme"],
+              "additionalProperties": false,
+              "properties": {
+                "keyid_hash_algorithms": {
+                  "type": "array",
+                  "items": {
+                    "enum": [
+                      "sha256",
+                      "sha512"
+                    ]
+                  }
+                },
+                "keytype": {
+                  "enum": ["rsa"]
+                },
+                "keyval": {
+                  "type": "object",
+                  "required": ["public"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "public": {
+                      "type": "string",
+                      "pattern": "^-----BEGIN PUBLIC KEY-----"
+                    }
+                  }
+                },
+                "scheme": {
+                  "enum": ["rsassa-pss-sha256"]
+                }
+              }
+            }
+          }
+        },
+        "roles": {
+          "type": "object",
+          "required": ["root", "snapshot", "targets", "timestamp"],
+          "additionalProperties": false,
+          "properties": {
+            "root": {
+              "type": "object",
+              "required": ["keyids", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "keyids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 64,
+                    "maxLength": 64,
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                },
+                "threshold": {
+                  "type": "number",
+                  "minimum": 1
+                }
+              }
+            },
+            "snapshot": {
+              "type": "object",
+              "required": ["keyids", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "keyids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 64,
+                    "maxLength": 64,
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                },
+                "threshold": {
+                  "type": "number",
+                  "minimum": 1
+                }
+              }
+            },
+            "targets": {
+              "type": "object",
+              "required": ["keyids", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "keyids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 64,
+                    "maxLength": 64,
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                },
+                "threshold": {
+                  "type": "number",
+                  "minimum": 1
+                }
+              }
+            },
+            "timestamp": {
+              "type": "object",
+              "required": ["keyids", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "keyids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 64,
+                    "maxLength": 64,
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                },
+                "threshold": {
+                  "type": "number",
+                  "minimum": 1
+                }
+              }
+            }
+          }
+        },
+        "spec_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]$"
+        },
+        "version": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/schemas/snapshot.schema.json
+++ b/schemas/snapshot.schema.json
@@ -1,0 +1,704 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "signatures": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keyid": {
+              "type": "string",
+              "minLength": 64,
+              "maxLength": 64,
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "sig": {
+              "type": "string",
+              "minLength": 1024,
+              "maxLength": 1024,
+              "pattern": "^[a-f0-9]{1024}$"
+            }
+          },
+          "required": [
+            "keyid",
+            "sig"
+          ]
+        }
+      ]
+    },
+    "signed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "_type": {
+          "enum": ["snapshot"]
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "in-toto-metadata-signer-0.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-1.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-2.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-3.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-4.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-5.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-6.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-7.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-8.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-9.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-a.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-b.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-c.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-d.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-e.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer-f.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "in-toto-metadata-signer.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "targets.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-a.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-b.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-c.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-d.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-e.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-f.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-g.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-h.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-i.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-j.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-k.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-l.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-m.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-n.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-o.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-p.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-q.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-r.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-s.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-t.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-u.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-v.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-w.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-x.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-y.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer-z.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            "wheels-signer.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            }
+          },
+          "required": [
+            "in-toto-metadata-signer-0.json",
+            "in-toto-metadata-signer-1.json",
+            "in-toto-metadata-signer-2.json",
+            "in-toto-metadata-signer-3.json",
+            "in-toto-metadata-signer-4.json",
+            "in-toto-metadata-signer-5.json",
+            "in-toto-metadata-signer-6.json",
+            "in-toto-metadata-signer-7.json",
+            "in-toto-metadata-signer-8.json",
+            "in-toto-metadata-signer-9.json",
+            "in-toto-metadata-signer-a.json",
+            "in-toto-metadata-signer-b.json",
+            "in-toto-metadata-signer-c.json",
+            "in-toto-metadata-signer-d.json",
+            "in-toto-metadata-signer-e.json",
+            "in-toto-metadata-signer-f.json",
+            "in-toto-metadata-signer.json",
+            "targets.json",
+            "wheels-signer-a.json",
+            "wheels-signer-b.json",
+            "wheels-signer-c.json",
+            "wheels-signer-d.json",
+            "wheels-signer-e.json",
+            "wheels-signer-f.json",
+            "wheels-signer-g.json",
+            "wheels-signer-h.json",
+            "wheels-signer-i.json",
+            "wheels-signer-j.json",
+            "wheels-signer-k.json",
+            "wheels-signer-l.json",
+            "wheels-signer-m.json",
+            "wheels-signer-n.json",
+            "wheels-signer-o.json",
+            "wheels-signer-p.json",
+            "wheels-signer-q.json",
+            "wheels-signer-r.json",
+            "wheels-signer-s.json",
+            "wheels-signer-t.json",
+            "wheels-signer-u.json",
+            "wheels-signer-v.json",
+            "wheels-signer-w.json",
+            "wheels-signer-x.json",
+            "wheels-signer-y.json",
+            "wheels-signer-z.json",
+            "wheels-signer.json"
+          ]
+        },
+        "spec_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]$"
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "_type",
+        "expires",
+        "meta",
+        "spec_version",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "signatures",
+    "signed"
+  ]
+}

--- a/schemas/targets.schema.json
+++ b/schemas/targets.schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "signatures": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keyid": {
+              "type": "string",
+              "minLength": 64,
+              "maxLength": 64,
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "sig": {
+              "type": "string",
+              "minLength": 1024,
+              "maxLength": 1024,
+              "pattern": "^[a-f0-9]{1024}$"
+            }
+          },
+          "required": [
+            "keyid",
+            "sig"
+          ]
+        }
+      ]
+    },
+    "signed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "_type": {
+          "enum": ["targets"]
+        },
+        "delegations": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keys": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-f0-9]{64}$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "keyid_hash_algorithms": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "enum": ["sha256", "sha512"]
+                        }
+                      ]
+                    },
+                    "keytype": {
+                      "enum": ["rsa"]
+                    },
+                    "keyval": {
+                      "type": "object",
+                      "required": ["public"],
+                      "additionalProperties": false,
+                      "properties": {
+                        "public": {
+                          "type": "string",
+                          "pattern": "^-----BEGIN PUBLIC KEY-----"
+                        }
+                      }
+                    },
+                    "scheme": {
+                      "enum": ["rsassa-pss-sha256"]
+                    }
+                  },
+                  "required": [
+                    "keyid_hash_algorithms",
+                    "keytype",
+                    "keyval",
+                    "scheme"
+                  ]
+                }
+              }
+            },
+            "roles": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "keyids": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "minLength": 64,
+                          "maxLength": 64,
+                          "pattern": "^[a-f0-9]{64}$"
+                        }
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "paths": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      ],
+                      "minLength": 1
+                    },
+                    "terminating": {
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  },
+                  "required": [
+                    "keyids",
+                    "name",
+                    "paths",
+                    "terminating",
+                    "threshold"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "keys",
+            "roles"
+          ]
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "spec_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]$"
+        },
+        "targets": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^in-toto-metadata/[0-9a-z.]+.layout$": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "custom": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "in-toto": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "pattern": "^in-toto-pubkeys/[a-f0-9]{64}.pub$"
+                        }
+                      ],
+                      "minLength": 1
+                    },
+                    "root-layout-type": {
+                      "enum": ["core", "extras"]
+                    }
+                  },
+                  "required": [
+                    "in-toto",
+                    "root-layout-type"
+                  ]
+                },
+                "hashes": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "sha256": {
+                      "type": "string",
+                      "minLength": 64,
+                      "maxLength": 64,
+                      "pattern": "^[a-f0-9]{64}$"
+                    },
+                    "sha512": {
+                      "type": "string",
+                      "minLength": 128,
+                      "maxLength": 128,
+                      "pattern": "^[a-f0-9]{128}$"
+                    }
+                  },
+                  "required": [
+                    "sha256",
+                    "sha512"
+                  ]
+                },
+                "length": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "custom",
+                "hashes",
+                "length"
+              ]
+            },
+            "^in-toto-pubkeys/[0-9a-f]{64}.pub$": {
+              "type": "object",
+              "properties": {
+                "custom": {
+                "type": "object"
+              },
+              "hashes": {
+                "type": "object",
+                "properties": {
+                  "sha256": {
+                    "type": "string",
+                    "minLength": 64,
+                    "maxLength": 64,
+                    "pattern": "^[a-f0-9]{64}$"
+                  },
+                  "sha512": {
+                    "type": "string",
+                    "minLength": 128,
+                    "maxLength": 128,
+                    "pattern": "^[a-f0-9]{128}$"
+                  }
+                },
+                "required": [
+                  "sha256",
+                  "sha512"
+                ]
+              },
+              "length": {
+                "type": "integer",
+                "minimum": 1
+              }
+            },
+            "required": [
+              "custom",
+              "hashes",
+              "length"
+            ]
+            }
+          }
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "_type",
+        "delegations",
+        "expires",
+        "spec_version",
+        "targets",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "signatures",
+    "signed"
+  ]
+}

--- a/schemas/timestamp.schema.json
+++ b/schemas/timestamp.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "signatures": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keyid": {
+              "type": "string",
+              "minLength": 64,
+              "maxLength": 64,
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "sig": {
+              "type": "string",
+              "minLength": 1024,
+              "maxLength": 1024,
+              "pattern": "^[a-f0-9]{1024}$"
+            }
+          },
+          "required": [
+            "keyid",
+            "sig"
+          ]
+        }
+      ]
+    },
+    "signed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "_type": {
+          "enum": ["timestamp"]
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "snapshot.json": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "hashes": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "sha256": {
+                      "type": "string",
+                      "minLength": 64,
+                      "maxLength": 64,
+                      "pattern": "^[a-f0-9]{64}$"
+                    },
+                    "sha512": {
+                      "type": "string",
+                      "minLength": 128,
+                      "maxLength": 128,
+                      "pattern": "^[a-f0-9]{128}$"
+                    }
+                  },
+                  "required": [
+                    "sha256",
+                    "sha512"
+                  ]
+                },
+                "length": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "version": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "hashes",
+                "length",
+                "version"
+              ]
+            }
+          },
+          "required": [
+            "snapshot.json"
+          ]
+        },
+        "spec_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]$"
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "_type",
+        "expires",
+        "meta",
+        "spec_version",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "signatures",
+    "signed"
+  ]
+}

--- a/schemas/wheels-signer-x.schema.json
+++ b/schemas/wheels-signer-x.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "signatures": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keyid": {
+              "type": "string",
+              "minLength": 64,
+              "maxLength": 64,
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "sig": {
+              "type": "string",
+              "minLength": 1024,
+              "maxLength": 1024,
+              "pattern": "^[a-f0-9]{1024}$"
+            }
+          },
+          "required": [
+            "keyid",
+            "sig"
+          ]
+        }
+      ]
+    },
+    "signed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "_type": {
+          "enum": ["targets"]
+        },
+        "delegations": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keys": {
+              "type": "object"
+            },
+            "roles": {
+              "type": "array",
+              "items": {}
+            }
+          },
+          "required": [
+            "keys",
+            "roles"
+          ]
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "spec_version": {
+          "type": "string",
+          "pattern": "[0-9]+\\.[0-9]+\\.[0-9]+"
+        },
+        "targets": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^simple/([a-z0-9-]+/[a-z0-9-_.]+-py2.py3-none-any.whl)?|(([a-z0-9-_]+/[a-z0-9-_.]+)?index.html)$": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "custom": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "in-toto": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "pattern": "in-toto-metadata/([a-f0-9]{64}/(wheels-signer|wheels-builder|tag)\\.[a-f0-9]{8}\\.link)|root.layout"
+                        }
+                      ]
+                    },
+                    "root-layout-type": {
+                      "enum": ["core", "extras"]
+                    }
+                  },
+                  "required": [
+                    "in-toto",
+                    "root-layout-type"
+                  ]
+                },
+                "hashes": {
+                  "type": "object",
+                  "properties": {
+                    "sha256": {
+                      "type": "string",
+                      "minLength": 64,
+                      "maxLength": 64,
+                      "pattern": "^[a-f0-9]{64}$"
+                    },
+                    "sha512": {
+                      "type": "string",
+                      "minLength": 128,
+                      "maxLength": 128,
+                      "pattern": "^[a-f0-9]{128}$"
+                    }
+                  },
+                  "required": [
+                    "sha256",
+                    "sha512"
+                  ]
+                },
+                "length": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "custom",
+                "hashes",
+                "length"
+              ]
+            }
+          }
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "_type",
+        "delegations",
+        "expires",
+        "spec_version",
+        "targets",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "signatures",
+    "signed"
+  ]
+}

--- a/schemas/wheels-signer.schema.json
+++ b/schemas/wheels-signer.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "signatures": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keyid": {
+              "type": "string",
+              "minLength": 64,
+              "maxLength": 64,
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "sig": {
+              "type": "string",
+              "minLength": 1024,
+              "maxLength": 1024,
+              "pattern": "^[a-f0-9]{1024}$"
+            }
+          },
+          "required": [
+            "keyid",
+            "sig"
+          ]
+        }
+      ]
+    },
+    "signed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "_type": {
+          "enum": ["targets"]
+        },
+        "delegations": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keys": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-f0-9]{64}$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "keyid_hash_algorithms": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "enum": ["sha256", "sha512"]
+                        }
+                      ]
+                    },
+                    "keytype": {
+                      "enum": ["rsa"]
+                    },
+                    "keyval": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "public": {
+                          "type": "string",
+                          "pattern": "^-----BEGIN PUBLIC KEY-----"
+                        }
+                      },
+                      "required": [
+                        "public"
+                      ]
+                    },
+                    "scheme": {
+                      "enum": ["rsassa-pss-sha256"]
+                    }
+                  },
+                  "required": [
+                    "keyid_hash_algorithms",
+                    "keytype",
+                    "keyval",
+                    "scheme"
+                  ]
+                }
+              }
+            },
+            "roles": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "keyids": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "minLength": 64,
+                          "maxLength": 64,
+                          "pattern": "^[a-f0-9]{64}$"
+                        }
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "paths": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "pattern": "^simple/((.+(.html|.whl))|(index.html))$"
+                        }
+                      ]
+                    },
+                    "terminating": {
+                      "type": "boolean"
+                    },
+                    "threshold": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  },
+                  "required": [
+                    "keyids",
+                    "name",
+                    "paths",
+                    "terminating",
+                    "threshold"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "keys",
+            "roles"
+          ]
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "spec_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]$"
+        },
+        "targets": {
+          "type": "object"
+        },
+        "version": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "_type",
+        "delegations",
+        "expires",
+        "spec_version",
+        "targets",
+        "version"
+      ]
+    }
+  },
+  "required": [
+    "signatures",
+    "signed"
+  ]
+}


### PR DESCRIPTION
Add TUF and in-toto JSON schema files. These schema files were produced as part of Datadog agent integration testsuite (additionally adjusted to remove Datadog specific parts) and have not been reviewed yet - I'm new to TUF/in-toto, so please review any possible inconsistencies and sorry for them.

Closes: #242
