### PR TITLE
Clone repository before setting up Python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,16 @@ jobs:
     name: Make and publish spec release
     runs-on: ubuntu-latest
     steps:
+    - name: Clone main
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      with:
+        fetch-depth: 0
+
     - name: Set up Python
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
       with:
         python-version: 3.x
         cache: 'pip'
-
-    - name: Clone main
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      with:
-        fetch-depth: 0
 
     - name: Get previous version
       id: prevver


### PR DESCRIPTION
Since 70f167f the setup-python action restores a cache based on the fingerprint of requirements.txt, therefore we must ensure a copy of that file exists before we setup Python. This order of events requires the first action to be checkout to clone the repository.

Signed-off-by: Joshua Lock <jlock@vmware.com>