### PR TITLE
Fix spec generation action following GitHub change

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
       with:
-        python-version: 3.x
+        python-version: '3.10'
         cache: pip
 
     - name: Clone

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
         with:
-          python-version: 3.x
+          python-version: '3.10'
           cache: pip
 
       - name: Ensure changes build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@b55428b1882923874294fa556849718a1d7f2ca5
       with:
-        python-version: 3.x
+        python-version: '3.10'
         cache: 'pip'
 
     - name: Get previous version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
       id: prevver
       run: |
         prev_version=`git tag | sort -V -r | head -n 1 | cut -c 2-`
-        echo "::set-output name=prev_version::$(echo -n $prev_version)"
+        echo "prev_version=$prev_version" >> $GITHUB_OUTPUT
 
     - name: Get version
       id: getver
       run: |
         spec_version=`grep -oP 'VERSION \K(\d+\.\d+\.\d+)' tuf-spec.md`
-        echo "::set-output name=spec_version::$(echo -n $spec_version)"
+        echo "spec_version=$spec_version" >> $GITHUB_OUTPUT
 
     - name: Make release
       if: steps.getver.outputs.spec_version != steps.prevver.outputs.prev_version


### PR DESCRIPTION
GitHub Actions are deprecating the set-output workflow command in favour of environmental files. This PR updates the release workflow to use the [new mechanism](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for saving output from a step.

Fixes: #259