### PR TITLE
Clarify current state of key formats in the spec

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -518,6 +518,8 @@ http://wiki.laptop.org/go/Canonical_JSON).
 
 ## File formats: general principles ## {#file-formats-general-principles}
 
+### Object format ### {#file-formats-object-format}
+
 All signed metadata objects have the format:
 
 <pre highlight="json">
@@ -545,7 +547,7 @@ All signed metadata objects have the format:
       ::
         A hex-encoded signature of the canonical form of the metadata for <a for="role">ROLE</a>.
 
-## File formats: keys ## {#file-formats-keys}
+### Key objects ### {#file-formats-keys}
 
 All <dfn>KEY</dfn> objects have the format:
 
@@ -655,7 +657,7 @@ The <dfn for="keytype">"ecdsa"</dfn> format is:
   ::
     PEM format and a string.
 
-## File formats: date-time ## {#file-formats-date-time}
+### Date-time ### {#file-formats-date-time}
 
 Metadata <dfn>date-time</dfn> follows the ISO 8601 standard.  The expected
 format of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -937,7 +937,7 @@ The "signed" portion of <dfn>targets.json</dfn> is as follows:
   "spec_version" : <a>SPEC_VERSION</a>,
   "version" : <a for="role">VERSION</a>,
   "expires" : <a>EXPIRES</a>,
-  "targets" : <a>TARGETS</a>,
+  "targets" : <a for="targets-obj">TARGETS</a>,
   ("delegations" : <a>DELEGATIONS</a>)
 }
 </pre>
@@ -971,8 +971,9 @@ as is described for the <a>root.json</a> file.
     definition](https://url.spec.whatwg.org/#path-relative-url-string) in the
     WHATWG URL specification.
 
-    It is allowed to have a <a>TARGETS</a> object with no <a>TARGETPATH</a>
-    elements.  This can be used to indicate that no target files are available.
+    It is allowed to have a <a for="targets-obj">TARGETS</a> object with no
+    <a>TARGETPATH</a> elements.  This can be used to indicate that no target
+    files are available.
 
   : <dfn for="targets-obj">LENGTH</dfn>
   ::
@@ -1652,9 +1653,9 @@ when adding targets to the repository, or updating existing targets.
 
 ### Update targets metadata ### {#update-targets-metadata}
 
-1. Add the new (or update an existing) <a>TARGETS</a> object in the relevant
-   targets metadata (either the top-level targets metadata, or a delegated
-   targets metadata).
+1. Add the new (or update an existing) <a for="targets-obj">TARGETS</a> object
+   in the relevant targets metadata (either the top-level targets metadata, or
+   a delegated targets metadata).
 2. Increment the <a for="role">VERSION</a> number in the updated targets
    metadata.
 3. Sign the updated targets metadata with at least a <a>THRESHOLD</a> of keys

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -3,7 +3,7 @@ Title: The Update Framework Specification
 Shortname: TUF
 Status: LS
 Abstract: A framework for securing software update systems.
-Date: 2022-09-09
+Date: 2023-03-02
 Editor: Justin Cappos, NYU
 Editor: Trishank Karthik Kuppusamy, Datadog
 Editor: Joshua Lock, Verizon
@@ -16,7 +16,7 @@ Boilerplate: copyright no, conformance no
 Local Boilerplate: header yes
 Markup Shorthands: css no, markdown yes
 Metadata Include: This version off, Abstract off
-Text Macro: VERSION 1.0.31
+Text Macro: VERSION 1.0.32
 </pre>
 
 Note: We strive to make the specification easy to implement, so if you come

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -545,8 +545,9 @@ All signed metadata objects have the format:
       ::
         A hex-encoded signature of the canonical form of the metadata for <a for="role">ROLE</a>.
 
+## File formats: keys ## {#file-formats-keys}
 
-All <dfn>KEY</dfn>s have the format:
+All <dfn>KEY</dfn> objects have the format:
 
 <pre highlight="json">
 {
@@ -653,6 +654,8 @@ The <dfn for="keytype">"ecdsa"</dfn> format is:
   : <dfn for="keyval-ecdsa">PUBLIC</dfn>
   ::
     PEM format and a string.
+
+## File formats: date-time ## {#file-formats-date-time}
 
 Metadata <dfn>date-time</dfn> follows the ISO 8601 standard.  The expected
 format of the combined date and time string is "YYYY-MM-DDTHH:MM:SSZ".  Time is

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -560,7 +560,7 @@ All <dfn>KEY</dfn>s have the format:
       ::
         A string denoting a public key signature system, such as <a
         for="keytype">"rsa"</a>, <a for="keytype">"ed25519"</a>, and <a
-        for="keytype">"ecdsa-sha2-nistp256"</a>.
+        for="keytype">"ecdsa"</a>.
 
       : <dfn>SCHEME</dfn>
       ::
@@ -572,9 +572,21 @@ All <dfn>KEY</dfn>s have the format:
       ::
         A dictionary containing the public portion of the key.
 
-The reference implementation defines three signature schemes, although TUF
-is not restricted to any particular signature scheme, key type, or
-cryptographic library:
+The reference implementation defines three <a>KEYTYPE</a>s:
+<a for="keytype">"rsa"</a>, <a for="keytype">"ed25519"</a>, and
+<a for="keytype">"ecdsa"</a>; and three signature <a>SCHEME</a>s:
+<a for="scheme">"rsassa-pss-sha256"</a>, <a for="scheme">"ed25519"</a>, and
+<a for="scheme">"ecdsa-sha2-nistp256"</a>. These are documented below.
+
+TUF is not restricted to any particular signature <a>SCHEME</a>s,
+<a>KEYTYPE</a>s, or cryptographic library. Adopters can define and use any
+particular <a>KEYTYPE</a>, signing <a>SCHEME</a>, and cryptographic library.
+
+Implementing the <a>KEYTYPE</a>s and <a>SCHEME</a>s below is RECOMMENDED for
+all implementations, as this enables interoperability. Conversely,
+implementations SHOULD NOT implement the <a>KEYTYPE</a>s and <a>SCHEME</a>s
+that are defined in a different manner than specified, so as to avoid confusion
+across implementations.
 
   : <dfn for="scheme">"rsassa-pss-sha256"</dfn>
   ::
@@ -593,11 +605,6 @@ cryptographic library:
     and SHA-256 hashing.
     [https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm
     ](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)
-
-We define three keytypes below: <a for="keytype">"rsa"</a>, <a
-for="keytype">"ed25519"</a>, and <a for="keytype">"ecdsa-sha2-nistp256"</a>, but adopters
-can define and use any particular keytype, signing scheme, and cryptographic
-library.
 
 The <dfn for="keytype">"rsa"</dfn> format is:
 
@@ -631,11 +638,11 @@ The <dfn for="keytype">"ed25519"</dfn> format is:
   ::
     64-byte hex encoded string.
 
-The <dfn for="keytype">"ecdsa-sha2-nistp256"</dfn> format is:
+The <dfn for="keytype">"ecdsa"</dfn> format is:
 
 <pre highlight="json">
 {
-  "keytype" : <a for="keytype">"ecdsa-sha2-nistp256"</a>,
+  "keytype" : <a for="keytype">"ecdsa"</a>,
   "scheme" : <a for="scheme">"ecdsa-sha2-nistp256"</a>,
   "keyval" : {
     "public" : <a for="keyval-ecdsa">PUBLIC</a>


### PR DESCRIPTION
Key formats are a recurring source of confusion (see https://github.com/secure-systems-lab/securesystemslib/issues/513, https://github.com/theupdateframework/specification/issues/201, and https://github.com/secure-systems-lab/securesystemslib/issues/308). Do we specify key formats, or simply record those used by the reference implementation? 

The current status is unclear, so this PR attempts to:
1. clarify that the spec only documents the key formats used by the reference implementation
2. recommend against redefining the formats documented in the spec
3. renames the "ecdsa-sha2-nistp256" key format to "ecdsa", per the reference implementation (https://github.com/secure-systems-lab/securesystemslib/pull/267)

The above changes are included in a single commit ac9fc63234c92483a1cda81bf3c148553bf6edcf.

There are additional changes in this PR to address a bikeshed error in newer versions of the generator (2de414906d634d2d24df30e51c0bd593791da0ff) and to add additional navigation headers to make it easier to find and link to details of the recommended file formats (5fef3750d9749bfd944fd8e513f928f2732c994b). I included these changes in one PR because the workflow is awkward for small changes. 

I encourage reviewers to use the commits tab and review each patch independently.

(Note: deeper discussions around key formats and specification vs. recommendation and interoperability of implementations is necessary, and has been added to the agenda 