### PR TITLE
Fix specification builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Make and publish spec release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # required to publish (tag) a release 
     steps:
     - name: Clone main
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   make-release:
     name: Make and publish spec release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Clone main
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab


### PR DESCRIPTION
Something changed in our GitHub Actions environment (either the platform itself or our organisation's default permissions) since the last specification release such that the build and publish workflow has failed for the most recent change.

This PR is the simplest fix, adding the required permissions for the workflow to succeed.