### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa
-      with:
-        python-version: '3.10'
-        cache: 'pip'
-
     - name: Get previous version
       id: prevver
       run: |
@@ -33,6 +27,13 @@ jobs:
       run: |
         spec_version=`grep -oP 'VERSION \K(\d+\.\d+\.\d+)' tuf-spec.md`
         echo "spec_version=$spec_version" >> $GITHUB_OUTPUT
+
+    - name: Set up Python
+      if: steps.getver.outputs.spec_version != steps.prevver.outputs.prev_version
+      uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa
+      with:
+        python-version: '3.10'
+        cache: 'pip'
 
     - name: Make release
       if: steps.getver.outputs.spec_version != steps.prevver.outputs.prev_version


### PR DESCRIPTION
Defer setting up Python (and, more importantly, failing to clean up a nonexistent pip cache dir when no Python packages have been installed) if there is no new spec to release.

Otherwise, you get spurious errors like [this](https://github.com/theupdateframework/specification/actions/runs/7116550212/job/19375232136).