### PR TITLE
Add `Delegation Removal` subsection to Repository Operations in specification Documentation

### DIFF
--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1725,7 +1725,7 @@ when adding targets to the repository, or updating existing targets.
    filename is prefixed with the <a for="role">VERSION</a> number if consistent
    snapshots are enabled for the repository.
 
-### delegation removal ### {#deleting-delegation}
+### Delete delegation ### {#deleting-delegation}
 
 If there is a delegatee you want to delete, you should delete:
 

--- a/tuf-spec.md
+++ b/tuf-spec.md
@@ -1725,6 +1725,18 @@ when adding targets to the repository, or updating existing targets.
    filename is prefixed with the <a for="role">VERSION</a> number if consistent
    snapshots are enabled for the repository.
 
+### delegation removal ### {#deleting-delegation}
+
+If there is a delegatee you want to delete, you should delete:
+
+1. The targets only the delegatee is responsible for.
+2. The delegatee's targets metadata.
+3. The delegation off any delegator's targets metadata.
+
+But keep the snapshot metadata about (2) around until timestamp/snapshot needs to be reset (e.g., due to a fast-forward attack, as described in Section [5.3.11][[#update-root]] of the spec).
+
+(3) can safely be updated in the snapshot(as described in Section [6.3.2][[#update-snapshot-metadata]] of the spec) metadata so long as it doesn't rollback itself.
+
 # Future directions and open questions # {#future-directions-and-open-questions}
 
 ## Support for bogus clocks ## {#support-for-bogus-clocks}


### PR DESCRIPTION
**Description:**
This PR adds a new section to the repository operations documentation titled "Delegation removal." The new section outlines the steps required to remove a delegatee, including the deletion of targets, the delegatee's targets metadata, and updating the delegator's targets metadata. Additionally, it specifies retaining snapshot metadata until a reset is needed and provides references to relevant sections for more details.

**Changes:**
- Added a new subsection `### Delegation removal {#deleting-delegation}` to the repository operations documentation.
- Included step-by-step instructions for delegation removal.
- Provided references to Section [5.3.11](https://theupdateframework.io/specification/latest/#update-root) for more details on updating root metadata and handling fast-forward attacks.
- Provided references to Section [6.3.2](https://theupdateframework.io/specification/latest/#update-snapshot-metadata) for more details on updating snapshot metadata.

**Reviewers:**
@trishankatdatadog @JustinCappos 

**Issue:**
Fixes #262

Thank you!