### PR TITLE
Add Community Specification License (CSL 1.0) files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,3 +91,11 @@ under Grant Nos. CNS-1345049 and CNS-0959138. Any opinions, findings, and
 conclusions or recommendations expressed in this material are those of the
 author(s) and do not necessarily reflect the views of the National Science
 Foundation.
+
+Governance & Licensing
+----------------------
+
+- `Scope <governance/02-scope.md>`_
+- `Notices <governance/03-notices.md>`_
+- `License <governance/04-license.md>`_
+- `Governance <governance/05-governance.md>`_

--- a/governance/00-contributor-license-agreement.md
+++ b/governance/00-contributor-license-agreement.md
@@ -1,0 +1,18 @@
+# Community Specification Contributor License Agreement 1.0
+
+By making a Contribution to this repository, I agree to the terms of the following documents located at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0):
+
+(a) Community Specification License 1.0 (.0_Community_Specification_License-v1.md)
+
+(b) Community Specification Governance Policy 1.0 (5._Governance.md)
+
+(c) Community Specification Contribution Policy 1.0 (6._Contributing.md)
+
+(d) Community Specification Code of Conduct (8._Code_of_Conduct.md)
+
+
+In addition, for source code contributions, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it. (d) I understand and agree that this working group and the contribution may be public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this agreement or the open source license(s) involved.
+
+I represent that I am legally entitled to make the grants set forth in the documents above.  If my employer(s) has rights to intellectual property that may be infringed by the materials developed by this Working Group, I represent that I have received permission to enter these agreements on behalf of that employer.

--- a/governance/01-community-specification-license-v1.md
+++ b/governance/01-community-specification-license-v1.md
@@ -1,0 +1,99 @@
+# Community Specification License 1.0
+
+**The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License's last section.
+
+**1.	Copyright.**
+
+**1.1.	Copyright License.**  Contributor grants everyone a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) copyright license, without any obligation for accounting, to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute any materials it submits to the full extent of its copyright interest in those materials. Contributor also acknowledges that the Working Group may exercise copyright rights in the Specification, including the rights to submit the Specification to another standards organization.
+
+**1.2.	Copyright Attribution.**  As a condition, anyone exercising this copyright license must include attribution to the Working Group in any derivative work based on materials developed by the Working Group.  That attribution must include, at minimum, the material's name, version number, and source from where the materials were retrieved.  Attribution is not required for implementations of the Specification.
+
+**2.	Patents.**
+
+**2.1.	Patent License.**
+
+**2.1.1.	As a Result of Contributions.**
+
+**2.1.1.1.	As a Result of Contributions to Draft Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims in 1) Contributor's Contributions and 2) to the Draft Specification that is within Scope as of the date of that Contribution, in both cases for Licensee's Implementation of the Draft Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.1.2.	For Approved Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims included in the Approved Specification that are within Scope for Licensee's Implementation of the Approved Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.2.	Patent Grant from Licensee.**  Licensee grants each other Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims for its Implementation, except for those patent claims excluded under Section 3.
+
+**2.1.3.	Licensee Acceptance.**  The patent grants set forth in Section 2.1 extend only to Licensees that have indicated their agreement to this License as follows:
+
+**2.1.3.1.	Source Code Distributions.**  For distribution in source code, by including this License in the root directory of the source code with the Implementation;
+
+**2.1.3.2.	Non-Source Code Distributions.**  For distribution in any form other than source code, by including this License in the documentation, legal notices, via notice in the software, and/or other written materials provided with the Implementation; or
+
+**2.1.3.3.	Via Notices.md.**  By issuing pull request or commit to the Specification's repository's Notices.md file by the Implementer's authorized representative, including the Implementer's name, authorized individual and system identifier, and Specification version.
+
+**2.1.4.	Defensive Termination.**  If any Licensee files or maintains a claim in a court asserting that a Necessary Claim is infringed by an Implementation, any licenses granted under this License to the Licensee are immediately terminated unless 1) that claim is directly in response to a claim against Licensee regarding an Implementation, or 2) that claim was brought to enforce the terms of this License, including intervention in a third-party action by a Licensee.
+
+**2.1.5.	Additional Conditions.**  This License is not an assurance (i) that any of Contributor's copyrights or issued patent claims cover an Implementation of the Specification or are enforceable or (ii) that an Implementation of the Specification would not infringe intellectual property rights of any third party.
+
+**2.2.	Patent Licensing Commitment.**  In addition to the rights granted in Section 2.1, Contributor agrees to grant everyone a no charge, royalty-free license on reasonable and non-discriminatory terms to Contributor's Necessary Claims that are within Scope for:
+1) Implementations of a Draft Specification, where such license applies only to those Necessary Claims infringed by implementing Contributor's Contribution(s) included in that Draft Specification, and
+2) Implementations of the Approved Specification.
+
+This patent licensing commitment does not apply to those claims subject to Contributor's Exclusion Notice under Section 3.
+
+**2.3.	Effect of Withdrawal.**  Contributor may withdraw from the Working Group by issuing a pull request or commit providing notice of withdrawal to the Working Group repository's Notices.md file.  All of Contributor's existing commitments and obligations with respect to the Working Group up to the date of that withdrawal notice will remain in effect, but no new obligations will be incurred.
+
+**2.4.	Binding Encumbrance.**  This License is binding on any future owner, assignee, or party who has been given the right to enforce any Necessary Claims against third parties.
+
+**3.	Patent Exclusion.**
+
+**3.1.	As a Result of Contributions.**  Contributor may exclude Necessary Claims from its licensing commitments incurred under Section 2.1.1 by issuing an Exclusion Notice within 45 days of the date of that Contribution.  Contributor may not issue an Exclusion Notice for any material that has been included in a Draft Deliverable for more than 45 days prior to the date of that Contribution.
+
+**3.2.	As a Result of a Draft Specification Becoming an Approved Specification.**  Prior to the adoption of a Draft Specification as an Approved Specification, Contributor may exclude Necessary Claims from its licensing commitments under this Agreement by issuing an Exclusion Notice.  Contributor may not issue an Exclusion Notice for patents that were eligible to have been excluded pursuant to Section 3.1.
+
+**4.	Source Code License.**  Any source code developed by the Working Group is solely subject the source code license included in the Working Group's repository for that code.  If no source code license is included, the source code will be subject to the MIT License.
+
+**5.	No Other Rights.**  Except as specifically set forth in this License, no other express or implied patent, trademark, copyright, or other rights are granted under this License, including by implication, waiver, or estoppel.
+
+**6.	Antitrust Compliance.**  Contributor acknowledge that it may compete with other participants in various lines of business and that it is therefore imperative that they and their respective representatives act in a manner that does not violate any applicable antitrust laws and regulations.  This License does not restrict any Contributor from engaging in similar specification development projects. Each Contributor may design, develop, manufacture, acquire or market competitive deliverables, products, and services, and conduct its business, in whatever way it chooses.  No Contributor is obligated to announce or market any products or services.  Without limiting the generality of the foregoing, the Contributors agree not to have any discussion relating to any product pricing, methods or channels of product distribution, division of markets, allocation of customers or any other topic that should not be discussed among competitors under the auspices of the Working Group.
+
+**7.	Non-Circumvention.**  Contributor agrees that it will not intentionally take or willfully assist any third party to take any action for the purpose of circumventing any obligations under this License.
+
+**8.	Representations, Warranties and Disclaimers.**
+
+**8.1.  Representations, Warranties and Disclaimers.**  Contributor and Licensee represents and warrants that 1) it is legally entitled to grant the rights set forth in this License and 2) it will not intentionally include any third party materials in any Contribution unless those materials are available under terms that do not conflict with this License.  IN ALL OTHER RESPECTS ITS CONTRIBUTIONS ARE PROVIDED "AS IS." The entire risk as to implementing or otherwise using the Contribution or the Specification is assumed by the implementer and user. Except as stated herein, CONTRIBUTOR AND LICENSEE EXPRESSLY DISCLAIM ANY WARRANTIES (EXPRESS, IMPLIED, OR OTHERWISE), INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, FITNESS FOR A PARTICULAR PURPOSE, CONDITIONS OF QUALITY, OR TITLE, RELATED TO THE CONTRIBUTION OR THE SPECIFICATION.  IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. Any obligations regarding the transfer, successors in interest, or assignment of Necessary Claims will be satisfied if Contributor or Licensee notifies the transferee or assignee of any patent that it knows contains Necessary Claims or necessary claims under this License. Nothing in this License requires Contributor to undertake a patent search. If Contributor is 1) employed by or acting on behalf of an employer, 2) is making a Contribution under the direction or control of a third party, or 3) is making the Contribution as a consultant, contractor, or under another similar relationship with a third party, Contributor represents that they have been authorized by that party to enter into this License on its behalf.
+
+**8.2.  Distribution Disclaimer.**  Any distributions of technical information to third parties must include a notice materially similar to the following: "THESE MATERIALS ARE PROVIDED "AS IS." The Contributors and Licensees expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.  The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user. IN NO EVENT WILL THE CONTRIBUTORS OR LICENSEES BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+
+**9.	Definitions.**
+
+**9.1.	Affiliate.** "Affiliate" means an entity that directly or indirectly Controls, is Controlled by, or is under common Control of that party.
+
+**9.2.	Approved Specification.**  "Approved Specification" means the final version and contents of any Draft Specification designated as an Approved Specification as set forth in the accompanying Governance.md file.
+
+**9.3.	Contribution.**  "Contribution" means any original work of authorship, including any modifications or additions to an existing work, that Contributor submits for inclusion in a Draft Specification, which is included in a Draft Specification or Approved Specification.
+
+**9.4.	Contributor.** "Contributor" means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the Community Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.5.	Control.**  "Control" means direct or indirect control of more than 50% of the voting power to elect directors of that corporation, or for any other entity, the power to direct management of such entity.
+
+**9.6.	Draft Specification.**  "Draft Specification" means all versions of the material (except an Approved Specification) developed by this Working Group for the purpose of creating, commenting on, revising, updating, modifying, or adding to any document that is to be considered for inclusion in the Approved Specification.
+
+**9.7.	Exclusion Notice.**  "Exclusion Notice" means a written notice made by making a pull request or commit to the repository's Notices.md file that identifies patents that Contributor is excluding from its patent licensing commitments under this License.  The Exclusion Notice for issued patents and published applications must include the Draft Specification's name, patent number(s) or title and application number(s), as the case may be, for each of the issued patent(s) or pending patent application(s) that the Contributor is excluding from the royalty-free licensing commitment set forth in this License.  If an issued patent or pending patent application that may contain Necessary Claims is not set forth in the Exclusion Notice, those Necessary Claims shall continue to be subject to the licensing commitments under this License.  The Exclusion Notice for unpublished patent applications must provide either: (i) the text of the filed application; or (ii) identification of the specific part(s) of the Draft Specification whose implementation makes the excluded claim a Necessary Claim.  If (ii) is chosen, the effect of the exclusion will be limited to the identified part(s) of the Draft Specification.
+
+**9.8.	Implementation.**  "Implementation" means making, using, selling, offering for sale, importing or distributing any implementation of the Specification 1) only to the extent it implements the Specification and 2) so long as all required portions of the Specification are implemented.
+
+**9.9.	License.**  "License" means this Community Specification License.
+
+**9.10.	Licensee.**  "Licensee" means any person or entity that has indicated its acceptance of the License as set forth in Section 2.1.3.  Licensee includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.11.	Necessary Claims.**  "Necessary Claims" are those patent claims, if any, that a party owns or controls, including those claims later acquired, that are necessary to implement the required portions (including the required elements of optional portions) of the Specification that are described in detail and not merely referenced in the Specification.
+
+**9.12.	Specification.**  "Specification" means a Draft Specification or Approved Specification included in the Working Group's repository subject to this License, and the version of the Specification implemented by the Licensee.
+
+**9.13.	Scope.**  "Scope" has the meaning as set forth in the accompanying Scope.md file included in this Specification's repository. Changes to Scope do not apply retroactively.  If no Scope is provided, each Contributor's Necessary Claims are limited to that Contributor's Contributions.
+
+**9.14.	Working Group.**  "Working Group" means this project to develop specifications, standards, best practices, guidelines, and other similar materials under this License.
+
+
+
+*The text of this Community Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -19,6 +19,5 @@ To prevent unintentional intellectual property encumbrance, the following areas 
 * **Transport Protocols:** The definition or standardization of network transport layers or delivery mechanisms (e.g., HTTP, gRPC, IPFS) used to transmit metadata or targets.
 * **Cryptographic Primitives:** The invention, modification, or primary standardization of underlying cryptographic algorithms (e.g., Ed25519, SHA-256). The specification relies entirely on existing cryptographic standards.
 * **Server-Side Architecture:** The design, implementation, and operational architecture of backend repository servers, metadata generation tools, or key management infrastructure at the implementation level. The specification governs the artifacts produced by the server and consumed by clients at an algorithmic level and does not mandate an exact means of producing the information.
-* **Ecosystem-Specific Adaptations:** Platform-specific integrations, package manager implementations, or language-specific APIs (e.g., Python PEP 458/459, Docker Content Trust) beyond the core, language-agnostic specification.
 * 
 Any changes of Scope are not retroactive.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -18,7 +18,7 @@ To prevent unintentional intellectual property encumbrance, the following areas 
 * **Payload Semantics:** The definition, structure, execution, or content of the target files distributed by the framework (e.g., binaries, containers, source code, or other supply chain metadata).
 * **Transport Protocols:** The definition or standardization of network transport layers or delivery mechanisms (e.g., HTTP, gRPC, IPFS) used to transmit metadata or targets.
 * **Cryptographic Primitives:** The invention, modification, or primary standardization of underlying cryptographic algorithms (e.g., Ed25519, SHA-256). The specification relies entirely on existing cryptographic standards.
-* **Server-Side Architecture:** The design, implementation, and operational architecture of backend repository servers, metadata generation tools, or key management infrastructure. The specification governs only the artifacts produced by the server, not the mechanisms of production.
+* **Server-Side Architecture:** The design, implementation, and operational architecture of backend repository servers, metadata generation tools, or key management infrastructure at the implementation level. The specification governs the artifacts produced by the server and consumed by clients at an algorithmic level and does not mandate an exact means of producing the information.
 * **Ecosystem-Specific Adaptations:** Platform-specific integrations, package manager implementations, or language-specific APIs (e.g., Python PEP 458/459, Docker Content Trust) beyond the core, language-agnostic specification.
 * 
 Any changes of Scope are not retroactive.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -1,0 +1,5 @@
+# Scope
+
+This Working Group standardizes The Update Framework (TUF), a framework for securing software update systems. In scope: the roles (root, targets, snapshot, and timestamp) and their metadata formats, the key management and delegation model, the client update workflow, and the threat model TUF defends against. Out of scope: specific implementations, the transport of files, and the software delivery mechanism itself.
+
+Any changes of Scope are not retroactive.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -1,5 +1,24 @@
-# Scope
+# Scope of The Update Framework (TUF) Specification Working Group
 
-This Working Group standardizes The Update Framework (TUF), a framework for securing software update systems. In scope: the roles (root, targets, snapshot, and timestamp) and their metadata formats, the key management and delegation model, the client update workflow, and the threat model TUF defends against. Out of scope: specific implementations, the transport of files, and the software delivery mechanism itself.
+## 1. Objective
+The objective of The Update Framework (TUF) Working Group is to define, standardize, and maintain a framework for securing software update systems, specifically mitigating known attacks against software repositories (e.g., rollback, freeze, mix-and-match, and malicious repository compromises).
 
+## 2. In Scope
+The Working Group's standard-setting activities are strictly limited to the following areas required to achieve client-server interoperability:
+
+* **Metadata Data Models and Schemas:** The structure, syntax, semantics, and serialization formats (e.g., canonical JSON) of the core TUF metadata roles (Root, Targets, Snapshot, Timestamp) and any standardized extension roles.
+* **Client Verification Workflow:** The step-by-step state machine, algorithmic logic, and failure conditions a client must execute to securely fetch, validate, and process repository metadata and target files.
+* **Delegation and Trust Boundaries:** Mechanisms for threshold signing, cryptographic key delegation, repository segmentation, and key revocation within the metadata structure.
+* **Cryptographic Representation:** The specifications for how cryptographic hashes, signatures, and key material are represented, encoded, and bound to the metadata roles.
+* **Threat Mitigation Definitions:** Explicit descriptions of the specific software update threat models the framework addresses, serving as the basis for the protocol's security properties.
+
+## 3. Out of Scope
+To prevent unintentional intellectual property encumbrance, the following areas are explicitly excluded from the Working Group's scope:
+
+* **Payload Semantics:** The definition, structure, execution, or content of the target files distributed by the framework (e.g., binaries, containers, source code, or other supply chain metadata).
+* **Transport Protocols:** The definition or standardization of network transport layers or delivery mechanisms (e.g., HTTP, gRPC, IPFS) used to transmit metadata or targets.
+* **Cryptographic Primitives:** The invention, modification, or primary standardization of underlying cryptographic algorithms (e.g., Ed25519, SHA-256). The specification relies entirely on existing cryptographic standards.
+* **Server-Side Architecture:** The design, implementation, and operational architecture of backend repository servers, metadata generation tools, or key management infrastructure. The specification governs only the artifacts produced by the server, not the mechanisms of production.
+* **Ecosystem-Specific Adaptations:** Platform-specific integrations, package manager implementations, or language-specific APIs (e.g., Python PEP 458/459, Docker Content Trust) beyond the core, language-agnostic specification.
+* 
 Any changes of Scope are not retroactive.

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -1,0 +1,58 @@
+# Notices
+
+## Code of Conduct
+
+Contact for Code of Conduct issues or inquiries:  Justin Cappos <jcappos@nyu.edu>
+
+[Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
+
+
+## License Acceptance
+
+Per Community Specification License 1.0 Section 2.1.3.3, Licensees may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification's repository's Notice.md file, including the Licensee's name, authorized individuals' names, and repository system identifier (e.g. GitHub ID), and specification version.
+
+A Licensee may consent to accepting the current Community Specification License version or any future version of the Community Specification License by indicating "or later" after their specification version.
+
+---------------------------------------------------------------------------------
+
+Licensee's name:
+
+Authorized individual and system identifier:
+
+Specification version:
+
+---------------------------------------------------------------------------------
+
+## Withdrawals
+
+Name of party withdrawing:
+
+Date of withdrawal:
+
+---------------------------------------------------------------------------------
+
+## Exclusions
+
+This section includes any Exclusion Notices made against a Draft Deliverable or Approved Deliverable as set forth in the Community Specification Development License. Each Exclusion Notice must include the following information:
+
+-	Name of party making the Exclusion Notice:
+
+-	Name of patent owner:
+
+-	Specification:
+
+-	Version number:
+
+**For issued patents and published patent applications:**
+
+	(i)	patent number(s) or title and application number(s), as the case may be:
+
+	(ii)	identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
+
+**For unpublished patent applications must provide either:**
+
+	(i) the text of the filed application; or
+
+	(ii) identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
+
+-----------------------------------------------------------------------------------------

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -4,8 +4,6 @@
 
 The Update Framework (TUF) is a [Cloud Native Computing Foundation](https://www.cncf.io/) project and follows the [TUF Community Code of Conduct](https://github.com/theupdateframework/community/blob/main/CODE-OF-CONDUCT.md), which follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-Contact for Code of Conduct issues or inquiries: the CNCF Code of Conduct Committee <conduct@cncf.io>.
-
 ## License Acceptance
 
 Per Community Specification License 1.0 Section 2.1.3.3, Licensees may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification's repository's Notice.md file, including the Licensee's name, authorized individuals' names, and repository system identifier (e.g. GitHub ID), and specification version.

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -2,10 +2,9 @@
 
 ## Code of Conduct
 
-Contact for Code of Conduct issues or inquiries:  Justin Cappos <jcappos@nyu.edu>
+The Update Framework (TUF) is a [Cloud Native Computing Foundation](https://www.cncf.io/) project and follows the [TUF Community Code of Conduct](https://github.com/theupdateframework/community/blob/main/CODE-OF-CONDUCT.md), which follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
-[Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
-
+Contact for Code of Conduct issues or inquiries: the CNCF Code of Conduct Committee <conduct@cncf.io>.
 
 ## License Acceptance
 

--- a/governance/04-license.md
+++ b/governance/04-license.md
@@ -1,0 +1,11 @@
+# Licenses
+
+## Specification License
+
+Specifications in this repository are subject to the **Community Specification License 1.0** available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+
+## Source Code License
+
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise marked.
+
+In the case of any conflict or confusion within this specification repository between the Community Specification License and the designated source code license, the terms of the Community Specification License shall apply.

--- a/governance/04-license.md
+++ b/governance/04-license.md
@@ -6,6 +6,6 @@ Specifications in this repository are subject to the **Community Specification L
 
 ## Source Code License
 
-If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license unless otherwise marked.
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the Apache-2.0 license unless otherwise marked.
 
 In the case of any conflict or confusion within this specification repository between the Community Specification License and the designated source code license, the terms of the Community Specification License shall apply.

--- a/governance/05-governance.md
+++ b/governance/05-governance.md
@@ -1,0 +1,51 @@
+# Community Specification Governance Policy 1.0
+
+This document provides the governance policy for specifications and other documents developed using the Community Specification process in a repository (each a "Working Group").  Each Working Group and must adhere to the requirements in this document.
+
+## 1.	Roles.
+
+Each Working Group may include the following roles. Additional roles may be adopted and documented by the Working Group.
+
+**1.1.	Maintainer.** "Maintainers" are responsible for organizing activities around developing, maintaining, and updating the specification(s) developed by the Working Group.  Maintainers are also responsible for determining consensus and coordinating appeals.  Each Working Group will designate one or more Maintainer for that Working Group.  A Working Group may select a new or additional Maintainer(s) upon Approval of the Working Group Participants.  
+
+**1.2.	Editor.**  "Editors" are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. Each Working Group will designate an Editor for that Working Group.  A Working Group may select a new Editor upon Approval of the Working Group Participants.
+
+**1.3.	Participants.**  "Participants" are those that have made Contributions to the Working Group subject to the Community Specification License.
+
+## 2.	Decision Making.
+
+**2.1.	Consensus-Based Decision Making.**  Working Groups make decisions through a consensus process ("Approval" or "Approved").  While the agreement of all Participants is preferred, it is not required for consensus.  Rather, the Maintainer will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the Working Group Participants and nature of support and objections.  The Maintainer will document evidence of consensus in accordance with these requirements. 
+
+**2.2.	Appeal Process.**  Decisions may be appealed be via a pull request or an issue, and that appeal will be considered by the Maintainer in good faith, who will respond in writing within a reasonable time.
+
+## 3.	Ways of Working.
+
+Inspired by [ANSI's Essential Requirements for Due Process](https://share.ansi.org/Shared%20Documents/Standards%20Activities/American%20National%20Standards/Procedures,%20Guides,%20and%20Forms/2020_ANSI_Essential_Requirements.pdf), Community Specification Working Groups must adhere to consensus-based due process requirements.  These requirements apply to activities related to the development of consensus for approval, revision, reaffirmation, and withdrawal of Community Specifications.  Due process means that any person (organization, company, government agency, individual, etc.) with a direct and material interest has a right to participate by: a) expressing a position and its basis, b) having that position considered, and c) having the right to appeal. Due process allows for equity and fair play. The following constitute the minimum acceptable due process requirements for the development of consensus.
+
+**3.1.	Openness.**  Participation shall be open to all persons who are directly and materially affected by the activity in question. There shall be no undue financial barriers to participation. Voting membership on the consensus body shall not be conditional upon membership in any organization, nor unreasonably restricted on the basis of technical qualifications or other such requirements.  Membership in a Working Group's parent organization, if any, may be required.
+
+**3.2.	Lack of Dominance.**  The development process shall not be dominated by any single interest category, individual or organization. Dominance means a position or exercise of dominant authority, leadership, or influence by reason of superior leverage, strength, or representation to the exclusion of fair and equitable consideration of other viewpoints.
+
+**3.3.	Balance.**  The development process should have a balance of interests. Participants from diverse interest categories shall be sought with the objective of achieving balance.
+
+**3.4.	Coordination and Harmonization.**  Good faith efforts shall be made to resolve potential conflicts between and among deliverables developed under this Working Group and existing industry standards.
+
+**3.5.	Consideration of Views and Objections.**  Prompt consideration shall be given to the written views and objections of all Participants.
+
+**3.6.	Written procedures.**  This governance document and other materials documenting the Community Specification development process shall be available to any interested person.
+
+## 4.	Specification Development Process.  
+
+**4.1.	Pre-Draft.**  Any Participant may submit a proposed initial draft document as a candidate Draft Specification of that Working Group.  The Maintainer will designate each submission as a "Pre-Draft" document.
+
+**4.2.	Draft.**  Each Pre-Draft document of a Working Group must first be Approved to become a" Draft Specification".  Once the Working Group approves a document as a Draft Specification, the Draft Specification becomes the basis for all going forward work on that specification.
+
+**4.3.	Working Group Approval.**  Once a Working Group believes it has achieved the objectives for its specification as described in the Scope, it will Approve that Draft Specification and progress it to "Approved Specification" status. 
+
+**4.4.	Publication and Submission.**  Upon the designation of a Draft Specification as an Approved Specification, the Maintainer will publish the Approved Specification in a manner agreed upon by the Working Group Participants (i.e., Working Group Participant only location, publicly available location, Working Group maintained website, Working Group member website, etc.).  The publication of an Approved Specification in a publicly accessible manner must include the terms under which the Approved Specification is being made available under.
+
+**4.5.	Submissions to Standards Bodies.**  No Draft Specification or Approved Specification may be submitted to another standards development organization without Working group Approval. Upon reaching Approval, the Maintainer will coordinate the submission of the applicable Draft Specification or Approved Specification to another standards development organization. Working Group Participants that developed that Draft Specification or Approved Specification agree to grant the copyright rights necessary to make those submissions.
+
+## 5. Non-Confidential, Restricted Disclosure.
+
+Information disclosed in connection with any Working Group activity, including but not limited to meetings, Contributions, and submissions, is not confidential, regardless of any markings or statements to the contrary.  Notwithstanding the foregoing, if the Working Group is collaborating via a private repository, the Participants will not make any public disclosures of that information contained in that private repository without the Approval of the Working Group.  


### PR DESCRIPTION
Draft: adds the CSL 1.0 file set (governance/00-05). LICENSE.md is already the CSL; this adds the governance file set and dual-licenses reference code under MIT. README.rst links to scope, notices, license, and governance. Note: a top-level GOVERNANCE.md already exists alongside the new governance/05-governance.md (CSL policy) to reconcile per maintainer preference.